### PR TITLE
Update to work with react-native v0.29 (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dependencies {
 ...
 import it.innove.BleManagerPackage; // <--- import
 
-public class MainActivity extends ReactActivity {
+public class MainApplication extends Application implements ReactApplication {
 
     ...
 
@@ -51,7 +51,7 @@ public class MainActivity extends ReactActivity {
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
-            new BleManagerPackage(this) // <------ add the package
+            new BleManagerPackage() // <------ add the package
         );
     }
 

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -1,6 +1,5 @@
 package it.innove;
 
-import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
@@ -29,7 +28,6 @@ class BleManager extends ReactContextBaseJavaModule {
 	private static final String LOG_TAG = "logs";
 
 
-	private static Activity activity;
 	private BluetoothAdapter bluetoothAdapter;
 	private Context context;
 	private ReactContext reactContext;
@@ -38,9 +36,8 @@ class BleManager extends ReactContextBaseJavaModule {
 	private Map<String, Peripheral> peripherals = new LinkedHashMap<>();
 
 
-	public BleManager(ReactApplicationContext reactContext, Activity activity) {
+	public BleManager(ReactApplicationContext reactContext) {
 		super(reactContext);
-		BleManager.activity = activity;
 		context = reactContext;
 		this.reactContext = reactContext;
 
@@ -137,7 +134,7 @@ class BleManager extends ReactContextBaseJavaModule {
 
 		Peripheral peripheral = peripherals.get(peripheralUUID);
 		if (peripheral != null){
-			peripheral.connect(successCallback, failCallback, activity);
+			peripheral.connect(successCallback, failCallback, getCurrentActivity());
 		} else
 			failCallback.invoke();
 	}

--- a/android/src/main/java/it/innove/BleManagerPackage.java
+++ b/android/src/main/java/it/innove/BleManagerPackage.java
@@ -1,6 +1,5 @@
 package it.innove;
 
-import android.app.Activity;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -14,18 +13,13 @@ import java.util.List;
 
 public class BleManagerPackage implements ReactPackage {
 
-	private Activity mActivity;
-
-	public BleManagerPackage(Activity activityContext) {
-		mActivity = activityContext;
-	}
-
+	public BleManagerPackage() {}
 
 	@Override
 	public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
 		List<NativeModule> modules = new ArrayList<>();
 
-		modules.add(new BleManager(reactApplicationContext, mActivity));
+		modules.add(new BleManager(reactApplicationContext));
 		return  modules;
 	}
 


### PR DESCRIPTION
The new version of react native seems to change Android application templates which breaks this module. According to the release notes:

"Plugins which pass activity reference in the constructor need to be updated to extend ReactContextBaseJavaModule use getCurrentActivity to get the activity reference. This change is backward compatible."