### PR TITLE
[iOS +  Android] Add methods to get discovered peripherals,  get connected peripherals, stop scan + somes fixes

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -127,6 +127,14 @@ class BleManager extends ReactContextBaseJavaModule {
 		successCallback.invoke();
 	}
 
+    @ReactMethod
+    public void stopScan(Callback successCallback) {
+        Log.d(LOG_TAG, "Stop scan");
+        if (!getBluetoothAdapter().isEnabled())
+            return;
+        getBluetoothAdapter().stopLeScan(mLeScanCallback);
+        successCallback.invoke();
+    }
 
 	@ReactMethod
 	public void connect(String peripheralUUID, Callback successCallback, Callback failCallback) {
@@ -309,7 +317,45 @@ class BleManager extends ReactContextBaseJavaModule {
 		}
 	};
 
+    @ReactMethod
+    public void getDiscoveredPeripherals(Callback callback) {
+        Log.d(LOG_TAG, "Get discovered peripherals");
+        WritableArray map = Arguments.createArray();
+        BundleJSONConverter bjc = new BundleJSONConverter();
+        for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
+            Map.Entry<String, Peripheral> entry = iterator.next();
+            Peripheral peripheral = entry.getValue();
+            try {
+                Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+                WritableMap jsonBundle = Arguments.fromBundle(bundle);
+                map.pushMap(jsonBundle);
+            } catch (JSONException ignored) {
 
+            }
+        }
+        callback.invoke(null, map);
+    }
+    
+    @ReactMethod
+    public void getConnectedPeripherals(Callback callback) {
+        Log.d(LOG_TAG, "Get connected peripherals");
+        WritableArray map = Arguments.createArray();
+        BundleJSONConverter bjc = new BundleJSONConverter();
+        for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
+            Map.Entry<String, Peripheral> entry = iterator.next();
+            Peripheral peripheral = entry.getValue();
+            if(peripheral.isConnected()){
+                try {
+                    Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+                    WritableMap jsonBundle = Arguments.fromBundle(bundle);
+                    map.pushMap(jsonBundle);
+                } catch (JSONException ignored) {
+
+                }
+            }
+        }
+        callback.invoke(null, map);
+    }
 
 
 	private final static char[] hexArray = "0123456789ABCDEF".toCharArray();

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -72,8 +72,7 @@ public class Peripheral extends BluetoothGattCallback {
 		connectCallback = null;
 		connected = false;
 		if (gatt != null) {
-			gatt.close();
-			gatt = null;
+			gatt.disconnect();
 			Log.d(LOG_TAG, "Disconnect");
 			WritableMap map = Arguments.createMap();
 			map.putString("peripheral", device.getAddress());
@@ -194,11 +193,6 @@ public class Peripheral extends BluetoothGattCallback {
 
 			if (connected) {
 				connected = false;
-
-				if (gatt != null) {
-					gatt.close();
-					gatt = null;
-				}
 
 				WritableMap map = Arguments.createMap();
 				map.putString("peripheral", device.getAddress());

--- a/ios/BleManager.h
+++ b/ios/BleManager.h
@@ -7,6 +7,7 @@
     NSMutableDictionary* connectCallbacks;
     NSMutableDictionary *readCallbacks;
     NSMutableDictionary *writeCallbacks;
+    NSMutableDictionary *writeErrorCallbacks;
     NSMutableArray *writeQueue;
     NSMutableDictionary *notificationCallbacks;
     NSMutableDictionary *stopNotificationCallbacks;


### PR DESCRIPTION
## ANDROID + iOS
* 3 methods were added:
```js
//Stop scan
BleManager.stopScan(function([Error], [Array]))

//Get already discovered peripherals
BleManager.getDiscoveredPeripherals(function([Error], [Array]))

//Get connected peripherals
BleManager.getConnectedPeripherals(function([Error], [Array]))
```

## ANDROID Only
* Use `gatt.disconnect()` instead `gatt.close()`.
Closing gatt will force use to restart ble adaptater.
* Do not close gatt after a disconnect

## iOs Only
* Add a `writeErrorCallbacks` property to handle correct error on write with response like UNLIKELY ERROR