### PR TITLE
[iOS] Fix forget to register writeErrorCallback + better getConnectedPeripherals on system only

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -337,14 +337,25 @@ class BleManager extends ReactContextBaseJavaModule {
     }
     
     @ReactMethod
-    public void getConnectedPeripherals(Callback callback) {
+    public void getConnectedPeripherals(ReadableArray serviceUUIDs, Callback callback) {
         Log.d(LOG_TAG, "Get connected peripherals");
         WritableArray map = Arguments.createArray();
         BundleJSONConverter bjc = new BundleJSONConverter();
         for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
             Map.Entry<String, Peripheral> entry = iterator.next();
             Peripheral peripheral = entry.getValue();
-            if(peripheral.isConnected()){
+            Boolean accept = false;
+
+            if (serviceUUIDs.size() > 0) {
+                for (int i = 0; i < serviceUUIDs.size(); i++) {
+                    accept = peripheral.hasService(UUIDHelper.uuidFromString(serviceUUIDs.getString(i)));
+                    Log.d(LOG_TAG, accept.toString());
+                }
+            } else {
+                accept = true;
+            }
+
+            if (peripheral.isConnected() && accept) {
                 try {
                     Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
                     WritableMap jsonBundle = Arguments.fromBundle(bundle);

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -169,6 +169,10 @@ public class Peripheral extends BluetoothGattCallback {
 		return device;
 	}
 
+	public Boolean hasService(UUID uuid){
+		return gatt.getService(uuid) != null;
+	}
+
 	@Override
 	public void onServicesDiscovered(BluetoothGatt gatt, int status) {
 		super.onServicesDiscovered(gatt, status);

--- a/ios/BleManager.xcodeproj/project.pbxproj
+++ b/ios/BleManager.xcodeproj/project.pbxproj
@@ -252,9 +252,10 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -271,9 +272,10 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Sorry, i forget to register the error callback in the write method, I also modify the getConnectedPeripherals to return only peripherals that are connected with the system.
It takes a new argument ServiceUUids