### PR TITLE
[iOS + Android] Add max byte size param to write method

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -14,9 +14,12 @@ class BleManager  {
     });
   }
 
-  write(peripheralId, serviceUUID, characteristicUUID, data) {
+  write(peripheralId, serviceUUID, characteristicUUID, data, maxByteSize) {
+    if (maxByteSize == null) {
+      maxByteSize = 20;
+    }
     return new Promise((fulfill, reject) => {
-      bleManager.write(peripheralId, serviceUUID, characteristicUUID, data, (success) => {
+      bleManager.write(peripheralId, serviceUUID, characteristicUUID, data, maxByteSize, (success) => {
         fulfill();
       }, (fail) => {
         reject(fail);

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ BleManager.read('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', 'XXXXXXXX-XXXX-XXXX-XXXX
   });
 ```
 
-### write(peripheralId, serviceUUID, characteristicUUID, data)
+### write(peripheralId, serviceUUID, characteristicUUID, data, maxByteSize)
 Write with response to the specified characteristic.
 Returns a `Promise` object.
 
@@ -205,6 +205,7 @@ __Arguments__
 - `serviceUUID` - `String` - the UUID of the service.
 - `characteristicUUID` - `String` - the UUID of the characteristic.
 - `data` - `String` - the data to write in Base64 format.
+- `maxByteSize` - `Integer` - specify the max byte size before splitting message
 
 To get the `data` into base64 format, you will need a library like `base64-js`. Install `base64-js`:
 

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -183,30 +183,30 @@ class BleManager extends ReactContextBaseJavaModule {
 
 
 	@ReactMethod
-	public void write(String deviceUUID, String serviceUUID, String characteristicUUID, String message, Callback successCallback, Callback failCallback) {
+	public void write(String deviceUUID, String serviceUUID, String characteristicUUID, String message, Integer maxByteSize, Callback successCallback, Callback failCallback) {
 		Log.d(LOG_TAG, "Write to: " + deviceUUID);
 
 		Peripheral peripheral = peripherals.get(deviceUUID);
 		if (peripheral != null){
 			byte[] decoded = Base64.decode(message.getBytes(), Base64.DEFAULT);
 			Log.d(LOG_TAG, "Message(" + decoded.length + "): " + bytesToHex(decoded));
-			peripheral.write(UUID.fromString(serviceUUID), UUID.fromString(characteristicUUID), decoded, successCallback, failCallback, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+			peripheral.write(UUID.fromString(serviceUUID), UUID.fromString(characteristicUUID), decoded, maxByteSize, successCallback, failCallback, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
 		} else
 			failCallback.invoke();
 	}
 
 	@ReactMethod
-	public void writeWithoutResponse(String deviceUUID, String serviceUUID, String characteristicUUID, String message, Callback successCallback, Callback failCallback) {
+	public void writeWithoutResponse(String deviceUUID, String serviceUUID, String characteristicUUID, String message, Integer maxByteSize, Callback successCallback, Callback failCallback) {
 		Log.d(LOG_TAG, "Write without response to: " + deviceUUID);
 
 		Peripheral peripheral = peripherals.get(deviceUUID);
 		if (peripheral != null){
 			byte[] decoded = Base64.decode(message.getBytes(), Base64.DEFAULT);
-			if (decoded.length > 20) {
-				failCallback.invoke("The max data size is 20");
+			if (decoded.length > maxByteSize) {
+				failCallback.invoke("The max data size is " + maxByteSize.toString());
 			} else {
 				Log.d(LOG_TAG, "Message(" + decoded.length + "): " + bytesToHex(decoded));
-				peripheral.write(UUID.fromString(serviceUUID), UUID.fromString(characteristicUUID), decoded, successCallback, failCallback, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
+				peripheral.write(UUID.fromString(serviceUUID), UUID.fromString(characteristicUUID), decoded, maxByteSize, successCallback, failCallback, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
 				successCallback.invoke();
 			}
 		} else

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -466,7 +466,7 @@ public class Peripheral extends BluetoothGattCallback {
 
 	}
 
-	public void write(UUID serviceUUID, UUID characteristicUUID, byte[] data, Callback successCallback, Callback failCallback, int writeType) {
+	public void write(UUID serviceUUID, UUID characteristicUUID, byte[] data, Integer maxByteSize, Callback successCallback, Callback failCallback, int writeType) {
 
 
 		if (gatt == null) {
@@ -498,18 +498,18 @@ public class Peripheral extends BluetoothGattCallback {
 					} else
 						successCallback.invoke();
 
-					if (data.length > 20) {
+					if (data.length > maxByteSize) {
 						int dataLength = data.length;
 						int count = 0;
 						byte[] firstMessage = null;
-						while (count < dataLength && (dataLength - count > 20)) {
+						while (count < dataLength && (dataLength - count > maxByteSize)) {
 							if (count == 0) {
-								firstMessage = Arrays.copyOfRange(data, count, count + 20);
+								firstMessage = Arrays.copyOfRange(data, count, count + maxByteSize);
 							} else {
-								byte[] splitMessage = Arrays.copyOfRange(data, count, count + 20);
+								byte[] splitMessage = Arrays.copyOfRange(data, count, count + maxByteSize);
 								writeQueue.add(splitMessage);
 							}
-							count += 20;
+							count += maxByteSize;
 						}
 						if (count < dataLength) {
 							// Other bytes in queue


### PR DESCRIPTION
I am working with a BLE device that requires a single message packet of > 20 bytes (23 in my case). I made these changes to allow the default max byte size for messages to be overridden if desired. The default is still `20`.

Before these changes the `react-native-ble-manager` library was incompatible with this device. After these changes, it is now fully compatible.

Would greatly appreciate feedback on this. And would hope to have the library support this functionality.