### PR TITLE
[iOS + Android] Fix getConnectedPeripherals and getDiscoveredPeripherals

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -110,10 +110,10 @@ class BleManager  {
   getConnectedPeripherals(serviceUUIDs) {
     return new Promise((fulfill, reject) => {
       bleManager.getConnectedPeripherals(serviceUUIDs, (result) => {
-        if (result[0] != null) {
-          reject(result[0])
+        if (result != null) {
+          fulfill(result);
         } else {
-          fulfill(result[1]);
+          fulfill([]);
         }
       });
     });
@@ -122,10 +122,10 @@ class BleManager  {
   getDiscoveredPeripherals() {
     return new Promise((fulfill, reject) => {
       bleManager.getDiscoveredPeripherals((result) => {
-        if (result[0] != null) {
-          reject(result[0])
+        if (result != null) {
+          fulfill(result);
         } else {
-          fulfill(result[1]);
+          fulfill([]);
         }
       });
     });

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -330,9 +330,9 @@ class BleManager extends ReactContextBaseJavaModule {
 
             }
         }
-        callback.invoke(null, map);
+        callback.invoke(map);
     }
-
+    
     @ReactMethod
     public void getConnectedPeripherals(ReadableArray serviceUUIDs, Callback callback) {
         Log.d(LOG_TAG, "Get connected peripherals");
@@ -361,7 +361,7 @@ class BleManager extends ReactContextBaseJavaModule {
                 }
             }
         }
-        callback.invoke(null, map);
+        callback.invoke(map);
     }
 
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -196,7 +196,7 @@ RCT_EXPORT_METHOD(getDiscoveredPeripheralsPeripherals:(nonnull RCTResponseSender
         NSDictionary * obj = [peripheral asDictionary];
         [discoveredPeripherals addObject:obj];
     }
-    callback(@[[NSNull null], [NSArray arrayWithArray:discoveredPeripherals]]);
+    callback(@[[NSArray arrayWithArray:discoveredPeripherals]]);
 }
 
 RCT_EXPORT_METHOD(getConnectedPeripherals:(NSArray *)serviceUUIDStrings callback:(nonnull RCTResponseSenderBlock)callback)
@@ -214,7 +214,8 @@ RCT_EXPORT_METHOD(getConnectedPeripherals:(NSArray *)serviceUUIDStrings callback
         NSDictionary * obj = [peripheral asDictionary];
         [foundedPeripherals addObject:obj];
     }
-    callback(@[[NSNull null], [NSArray arrayWithArray:foundedPeripherals]]);
+    
+    callback(@[[NSArray arrayWithArray:foundedPeripherals]]);
 }
 
 RCT_EXPORT_METHOD(scan:(NSArray *)serviceUUIDStrings timeoutSeconds:(nonnull NSNumber *)timeoutSeconds allowDuplicates:(BOOL)allowDuplicates callback:(nonnull RCTResponseSenderBlock)successCallback)


### PR DESCRIPTION
These methods were not working for me. They were seeming to return 2 element arrays with `null` as the first item, then checking if `result[0] != null` (which would always be false), triggering `fulfill(result[1])` (which could be null if no peripherals were found).

With the code as-is I kept getting the following error on iOS and Android: `null is not an object (evaluating 'result[0]')` on `BleManager.js:113`. It seems that `result` itself was being set to null and therefore `result[0]` was failing.

The following changes cause things to work correctly for me in iOS/Android. I also changed it so it simply returns an empty array if no devices are found, rather than a promise rejection.

@Rmannn please chime in if I'm missing something or way off base here.