### PR TITLE
Fix context issue with isPeripheralConnected and make getDiscoveredPeripherals thread-safe

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -4,6 +4,10 @@ var bleManager = React.NativeModules.BleManager;
 
 class BleManager  {
 
+  constructor() {
+    this.isPeripheralConnected = this.isPeripheralConnected.bind(this);
+  }
+
   read(peripheralId, serviceUUID, characteristicUUID) {
     return new Promise((fulfill, reject) => {
       bleManager.read(peripheralId, serviceUUID, characteristicUUID, (success) => {
@@ -132,8 +136,8 @@ class BleManager  {
   }
 
   isPeripheralConnected(peripheralId, serviceUUIDs) {
-    return this.getConnectedPeripherals(serviceUUIDs).then(function(result) {
-      if (result.find(function(p) { return p.id === peripheralId; })) {
+    return this.getConnectedPeripherals(serviceUUIDs).then((result) => {
+      if (result.find((p) => { return p.id === peripheralId; })) {
         return true;
       } else {
         return false;

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -192,9 +192,11 @@ RCT_EXPORT_METHOD(getDiscoveredPeripherals:(nonnull RCTResponseSenderBlock)callb
 {
     NSLog(@"Get discovered peripherals");
     NSMutableArray *discoveredPeripherals = [NSMutableArray array];
-    for(CBPeripheral *peripheral in peripherals){
+    @synchronized(peripherals) {
+      for(CBPeripheral *peripheral in peripherals){
         NSDictionary * obj = [peripheral asDictionary];
         [discoveredPeripherals addObject:obj];
+      }
     }
     callback(@[[NSArray arrayWithArray:discoveredPeripherals]]);
 }


### PR DESCRIPTION
Was getting "mutated while being enumerated" error because `peripherals` was being updated during discovery while I was attempting to read `getDiscoveredPeripherals`. This locks it while it's being looped through.

Also was running into a context issue in `isPeripheralConnected`. Fixed that as well.