### PR TITLE
Fix multiple failCallbacks being triggered

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -372,8 +372,7 @@ RCT_EXPORT_METHOD(write:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUI
         } else {
             [peripheral writeValue:dataMessage forCharacteristic:characteristic type:CBCharacteristicWriteWithResponse];
         }
-    }else
-        failCallback(@[@"Error"]);
+    }
 }
 
 
@@ -391,8 +390,7 @@ RCT_EXPORT_METHOD(writeWithoutResponse:(NSString *)deviceUUID serviceUUID:(NSStr
         NSLog(@"Message to write(%lu): %@ ", (unsigned long)[dataMessage length], [dataMessage hexadecimalString]);
         [peripheral writeValue:dataMessage forCharacteristic:characteristic type:CBCharacteristicWriteWithoutResponse];
         successCallback(@[]);
-    }else
-        failCallback(@[@"Error"]);
+    }
 }
 
 


### PR DESCRIPTION
I get an error when these failCallbacks are triggered because they are also being passed to `BLECommandContext` which is triggering them upon certain conditions. `nil` is returned when there is an error and then they are triggered for a second time in the `write` functions. Removing them seems to fix the issues without any adverse side effects.