### PR TITLE
Check the peripheral id is valid before creating a Bluetooth Device in the android connect method

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -262,11 +262,18 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 		Log.d(LOG_TAG, "Connect to: " + peripheralUUID );
 
 		Peripheral peripheral = peripherals.get(peripheralUUID);
-		if (peripheral == null){
-			peripheralUUID = peripheralUUID.toUpperCase();
-			BluetoothDevice device = bluetoothAdapter.getRemoteDevice(peripheralUUID);
-			peripheral = new Peripheral(device, reactContext);
-			peripherals.put(peripheralUUID, peripheral);
+		if (peripheral == null) {
+			if (peripheralUUID != null) {
+				peripheralUUID = peripheralUUID.toUpperCase();
+			}
+			if (bluetoothAdapter.checkBluetoothAddress(peripheralUUID)) {
+				BluetoothDevice device = bluetoothAdapter.getRemoteDevice(peripheralUUID);
+				peripheral = new Peripheral(device, reactContext);
+				peripherals.put(peripheralUUID, peripheral);
+			} else {
+				callback.invoke("Invalid peripheral uuid");
+				return;
+			}
 		}
 		peripheral.connect(callback, getCurrentActivity());
 	}


### PR DESCRIPTION
This fixes invalid or null peripheral id.

The method checkBluetoothAddress actually validates the address if it is uppercase.
If the address is null or not a valid bluetooth address, the callback is called with an error.

Feel free to edit the error message or anything you want