### PR TITLE
bug fix - findPeripheralByUUID

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -223,6 +223,7 @@ RCT_EXPORT_METHOD(start:(NSDictionary *)options callback:(nonnull RCTResponseSen
 {
     NSLog(@"BleManager initialized");
     NSDictionary *initOptions = nil;
+    [peripherals removeAllObjects];
     if ([[options allKeys] containsObject:@"showAlert"]){
         BOOL showAlert = [[options valueForKey:@"showAlert"] boolValue];
         initOptions = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:showAlert] forKey:CBCentralManagerOptionShowPowerAlertKey];


### PR DESCRIPTION
When you are using BleManager on same device (printer etc) multiple time. findPeripheralByUUID return wrong object(same uuid - another/old/ discovered object). I have 2 idea. 
#1. remove from peripherals same uuid objects before add.
#2. clear peripherals list start function.
