### PR TITLE
iOS: Stop NSTimer on manual stopScan

### DIFF
--- a/ios/BleManager.h
+++ b/ios/BleManager.h
@@ -17,6 +17,7 @@
 
 @property (strong, nonatomic) NSMutableSet *peripherals;
 @property (strong, nonatomic) CBCentralManager *manager;
+@property (weak, nonatomic) NSTimer *scanTimer;
 
 
 @end


### PR DESCRIPTION
Invalidate NSTimer created to stop scanning of scanForPeripheralsWithServices.
This will prevent 'unexpected' [manager stopScan] when manual stopScan called before scan timeout.