### PR TITLE
changed activity request code

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -35,7 +35,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 class BleManager extends ReactContextBaseJavaModule implements ActivityEventListener {
 
 	private static final String LOG_TAG = "logs";
-	static final int ENABLE_REQUEST = 1;
+	static final int ENABLE_REQUEST = 539;
 
 
 	private BluetoothAdapter bluetoothAdapter;


### PR DESCRIPTION
request code 1 is very commonly used as the default, and so there is a high chance for conflicts that can take quite a while to debug (I had a conflict with react-native-android-location-services-dialog-box). It's best to choose a number that's a bit more random.