### PR TITLE
stopping scan only if bt adapter is still ON / NullPointerException fix in Peripheral / cleanup

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -35,7 +35,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 class BleManager extends ReactContextBaseJavaModule implements ActivityEventListener {
 
 	private static final String LOG_TAG = "logs";
-	static final int ENABLE_REQUEST = 539;
+	private static final int ENABLE_REQUEST = 539;
 
 
 	private BluetoothAdapter bluetoothAdapter;
@@ -163,15 +163,13 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 							Peripheral peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord().getBytes(), reactContext);
 							peripherals.put(address, peripheral);
 
-							BundleJSONConverter bjc = new BundleJSONConverter();
 							try {
-								Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+								Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
 								WritableMap map = Arguments.fromBundle(bundle);
 								sendEvent("BleManagerDiscoverPeripheral", map);
 							} catch (JSONException ignored) {
 
 							}
-
 
 						} else {
 							// this isn't necessary
@@ -309,7 +307,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			if (peripheralUUID != null) {
 				peripheralUUID = peripheralUUID.toUpperCase();
 			}
-			if (bluetoothAdapter.checkBluetoothAddress(peripheralUUID)) {
+			if (BluetoothAdapter.checkBluetoothAddress(peripheralUUID)) {
 				BluetoothDevice device = bluetoothAdapter.getRemoteDevice(peripheralUUID);
 				peripheral = new Peripheral(device, reactContext);
 				peripherals.put(peripheralUUID, peripheral);
@@ -421,15 +419,13 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 								Peripheral peripheral = new Peripheral(device, rssi, scanRecord, reactContext);
 								peripherals.put(device.getAddress(), peripheral);
 
-								BundleJSONConverter bjc = new BundleJSONConverter();
 								try {
-									Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+									Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
 									WritableMap map = Arguments.fromBundle(bundle);
 									sendEvent("BleManagerDiscoverPeripheral", map);
 								} catch (JSONException ignored) {
 
 								}
-
 
 							} else {
 								// this isn't necessary
@@ -450,7 +446,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 		BluetoothAdapter adapter = getBluetoothAdapter();
 		String state = "off";
 		if (adapter != null) {
-			switch (adapter.getState()){
+			switch (adapter.getState()) {
 				case BluetoothAdapter.STATE_ON:
 					state = "on";
 					break;
@@ -502,12 +498,10 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	public void getDiscoveredPeripherals(Callback callback) {
 		Log.d(LOG_TAG, "Get discovered peripherals");
 		WritableArray map = Arguments.createArray();
-		BundleJSONConverter bjc = new BundleJSONConverter();
-		for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
-			Map.Entry<String, Peripheral> entry = iterator.next();
+		for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
 			Peripheral peripheral = entry.getValue();
 			try {
-				Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+				Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
 				WritableMap jsonBundle = Arguments.fromBundle(bundle);
 				map.pushMap(jsonBundle);
 			} catch (JSONException ignored) {
@@ -521,9 +515,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	public void getConnectedPeripherals(ReadableArray serviceUUIDs, Callback callback) {
 		Log.d(LOG_TAG, "Get connected peripherals");
 		WritableArray map = Arguments.createArray();
-		BundleJSONConverter bjc = new BundleJSONConverter();
-		for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
-			Map.Entry<String, Peripheral> entry = iterator.next();
+		for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
 			Peripheral peripheral = entry.getValue();
 			Boolean accept = false;
 
@@ -537,7 +529,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 
 			if (peripheral.isConnected() && accept) {
 				try {
-					Bundle bundle = bjc.convertToBundle(peripheral.asJSONObject());
+					Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
 					WritableMap jsonBundle = Arguments.fromBundle(bundle);
 					map.pushMap(jsonBundle);
 				} catch (JSONException ignored) {

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -205,9 +205,12 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 					runOnUiThread(new Runnable() {
 						@Override
 						public void run() {
+							BluetoothAdapter btAdapter = getBluetoothAdapter();
 							// check current scan session was not stopped
 							if (scanSessionId.intValue() == currentScanSession) {
-								getBluetoothAdapter().getBluetoothLeScanner().stopScan(mScanCallback);
+								if(btAdapter.getState() == BluetoothAdapter.STATE_ON) {
+									btAdapter.getBluetoothLeScanner().stopScan(mScanCallback);
+								}
 								WritableMap map = Arguments.createMap();
 								sendEvent("BleManagerStopScan", map);
 							}
@@ -239,9 +242,12 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 					runOnUiThread(new Runnable() {
 						@Override
 						public void run() {
+							BluetoothAdapter btAdapter = getBluetoothAdapter();
 							// check current scan session was not stopped
 							if (scanSessionId.intValue() == currentScanSession) {
-								getBluetoothAdapter().stopLeScan(mLeScanCallback);
+								if(btAdapter.getState() == BluetoothAdapter.STATE_ON) {
+									btAdapter.stopLeScan(mLeScanCallback);
+								}
 								WritableMap map = Arguments.createMap();
 								sendEvent("BleManagerStopScan", map);
 							}

--- a/android/src/main/java/it/innove/BleManagerPackage.java
+++ b/android/src/main/java/it/innove/BleManagerPackage.java
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -30,6 +30,6 @@ public class BleManagerPackage implements ReactPackage {
 
 	@Override
 	public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
-		return Arrays.asList();
+		return Collections.emptyList();
 	}
 }

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -1,14 +1,23 @@
 package it.innove;
 
 import android.app.Activity;
-import android.bluetooth.*;
-import android.os.Bundle;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattService;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;
-import com.facebook.react.bridge.*;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
-import org.json.JSONArray;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -16,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Peripheral wraps the BluetoothDevice and provides methods to convert to JSON.
@@ -487,8 +495,7 @@ public class Peripheral extends BluetoothGattCallback {
 
 		readRSSICallback = callback;
 
-		if (gatt.readRemoteRssi()) {
-		} else {
+		if (!gatt.readRemoteRssi()) {
 			readCallback = null;
 			callback.invoke("Read RSSI failed", null);
 		}
@@ -536,11 +543,11 @@ public class Peripheral extends BluetoothGattCallback {
 		} else {
 			BluetoothGattService service = gatt.getService(serviceUUID);
 			BluetoothGattCharacteristic characteristic = findWritableCharacteristic(service, characteristicUUID, writeType);
-			characteristic.setWriteType(writeType);
 
 			if (characteristic == null) {
 				callback.invoke("Characteristic " + characteristicUUID + " not found.");
 			} else {
+				characteristic.setWriteType(writeType);
 
 				if (writeQueue.size() > 0) {
 					callback.invoke("You have already an queued message");
@@ -595,7 +602,6 @@ public class Peripheral extends BluetoothGattCallback {
 						}
 					} else {
 						characteristic.setValue(data);
-
 
 						if (gatt.writeCharacteristic(characteristic)) {
 							Log.d(LOG_TAG, "Write completed");


### PR DESCRIPTION
- preventing crash when user disables bluetooth before scan is stopped (see commit message)
- preventing NullPointerException in write() method in Peripheral.java
- cleaned up some code