### PR TITLE
Added a removePeripheral method to delete a cached peripheral from the list

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -203,6 +203,18 @@ class BleManager  {
     });
   }
 
+  removePeripheral(peripheralId) {
+    return new Promise((fulfill, reject) => {
+      bleManager.removePeripheral(peripheralId, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          fulfill();
+        }
+      });
+    });
+  }
+
   isPeripheralConnected(peripheralId, serviceUUIDs) {
     return this.getConnectedPeripherals(serviceUUIDs).then((result) => {
       if (result.find((p) => { return p.id === peripheralId; })) {

--- a/README.md
+++ b/README.md
@@ -450,6 +450,14 @@ BleManager.getDiscoveredPeripherals([])
 
 ```
 
+### removePeripheral(peripheralId)
+Removes a disconnected peripheral from the cached list.
+It is useful if the device is turned off, because it will be re-discovered upon turning on again.
+Returns a `Promise` object.
+
+__Arguments__
+- `peripheralId` - `String` - the id/mac address of the peripheral.
+
 ### isPeripheralConnected(peripheralId, serviceUUIDs)
 Check whether a specific peripheral is connected and return `true` or `false`.
 Returns a `Promise` object.

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -391,6 +391,19 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 		callback.invoke(null, map);
 	}
 
+	@ReactMethod
+	public void removePeripheral(String deviceUUID, Callback callback) {
+		Log.d(LOG_TAG, "Removing from list: " + deviceUUID);
+		Peripheral peripheral = peripherals.get(deviceUUID);
+		if (peripheral != null){
+      if (peripheral.isConnected()) {
+				callback.invoke("Peripheral can not be removed while connected");
+      } else {
+				peripherals.remove(deviceUUID);
+      }
+		} else
+			callback.invoke("Peripheral not found");
+  }
 
 	private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
 


### PR DESCRIPTION
Sort of a fix for #126 
Allows the user to manually remove a disconnected device from the 'peripherals', so a new event is fired for it after the device is re-discovered.
It is useful for my scenario, in which devices timeout and turn themselves off and on and I need to reconnect to them each time.