### PR TITLE
(android fix) BleManager should still report a peripheral to JS with …

### DIFF
--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -36,24 +36,23 @@ public class LegacyScanManager extends ScanManager {
 						public void run() {
 							Log.i(bleManager.LOG_TAG, "DiscoverPeripheral: " + device.getName());
 							String address = device.getAddress();
+							Peripheral peripheral;
 
 							if (!bleManager.peripherals.containsKey(address)) {
-
-								Peripheral peripheral = new Peripheral(device, rssi, scanRecord, reactContext);
+								peripheral = new Peripheral(device, rssi, scanRecord, reactContext);
 								bleManager.peripherals.put(device.getAddress(), peripheral);
-
-								try {
-									Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-									WritableMap map = Arguments.fromBundle(bundle);
-									bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
-								} catch (JSONException ignored) {
-
-								}
-
 							} else {
-								// this isn't necessary
-								Peripheral peripheral = bleManager.peripherals.get(address);
+								peripheral = bleManager.peripherals.get(address);
 								peripheral.updateRssi(rssi);
+								peripheral.updateData(scanRecord);
+							}
+
+							try {
+								Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
+								WritableMap map = Arguments.fromBundle(bundle);
+								bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
+							} catch (JSONException ignored) {
+
 							}
 						}
 					});

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -101,24 +101,23 @@ public class LollipopScanManager extends ScanManager {
 				public void run() {
 					Log.i(bleManager.LOG_TAG, "DiscoverPeripheral: " + result.getDevice().getName());
 					String address = result.getDevice().getAddress();
+                    Peripheral peripheral = null;
 
 					if (!bleManager.peripherals.containsKey(address)) {
-
-						Peripheral peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord().getBytes(), reactContext);
+						peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord().getBytes(), reactContext);
 						bleManager.peripherals.put(address, peripheral);
-
-						try {
-							Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-							WritableMap map = Arguments.fromBundle(bundle);
-							bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
-						} catch (JSONException ignored) {
-
-						}
-
 					} else {
-						// this isn't necessary
-						Peripheral peripheral = bleManager.peripherals.get(address);
+						peripheral = bleManager.peripherals.get(address);
 						peripheral.updateRssi(result.getRssi());
+						peripheral.updateData(result.getScanRecord().getBytes());
+					}
+
+					try {
+						Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
+						WritableMap map = Arguments.fromBundle(bundle);
+						bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
+					} catch (JSONException ignored) {
+
 					}
 				}
 			});

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -281,6 +281,10 @@ public class Peripheral extends BluetoothGattCallback {
 		advertisingRSSI = rssi;
 	}
 
+	public void updateData(byte[] data) {
+		advertisingData = data;
+	}
+
 	public int unsignedToBytes(byte b) {
 		return b & 0xFF;
 	}


### PR DESCRIPTION
Reason for this patch
--

If the advertising data in peripheral has been changed during scanning, BleManager (for Android) will not report it to JavaScript side. This is because the native side only update RSSI and not emit a event.

It seems that the original code has a logic to determine whether emit a event to JS or not, however I think BleManager (as a bridge) should simply "relay" whatever operating system given.

Besides that, capture advertising data change is actually required for some use cases, such as a broadcasting only BLE peripheral might change its advertising data constantly according to environment.

This patch has been tested with Android 5 / 6 / 7, and by applying this, the BleManager scan behavior is now consistent with iOS side.