### PR TITLE
(android fix) startNotification promise should be resolved after rece…

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -44,6 +44,7 @@ public class Peripheral extends BluetoothGattCallback {
 	private Callback readCallback;
 	private Callback readRSSICallback;
 	private Callback writeCallback;
+	private Callback registerNotifyCallback;
 
 	private List<byte[]> writeQueue = new ArrayList<>();
 
@@ -355,6 +356,15 @@ public class Peripheral extends BluetoothGattCallback {
 	@Override
 	public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
 		super.onDescriptorWrite(gatt, descriptor, status);
+		if (registerNotifyCallback != null) {
+			if (status == BluetoothGatt.GATT_SUCCESS) {
+				registerNotifyCallback.invoke();
+			} else {
+				registerNotifyCallback.invoke("Error writing descriptor stats=" + status, null);
+			}
+
+			registerNotifyCallback = null;
+		}
 	}
 
 	@Override
@@ -403,7 +413,7 @@ public class Peripheral extends BluetoothGattCallback {
 					try {
 						if (gatt.writeDescriptor(descriptor)) {
 							Log.d(LOG_TAG, "setNotify complete");
-							callback.invoke();
+							registerNotifyCallback = callback;
 						} else {
 							callback.invoke("Failed to set client characteristic notification for " + characteristicUUID);
 						}


### PR DESCRIPTION
Reason for this patch
--

Original codes use `writeDescriptor` in a synchronous manner. 

However, from Android doc https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html, we can see the writeDescriptor just indicate whether init is success and the actual result comes from onDescriptorWrite callback.

In this patch, we only resolve the startNotification promise after receiving native callback. After apply this, we can successfully read characteristic in startNotification's fulfill callback. 

The solution is tested using TI Sensor Tag + Sony Tablet z4 (Android 7).

Thanks:)


