### PR TITLE
'setTimeOut' method referenced to global one rather than scoped

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -119,7 +119,7 @@ export default class App extends Component {
             this.setState({peripherals});
           }
           console.log('Connected to ' + peripheral.id);
-          this.setTimeout(() => {
+          setTimeout(() => {
 
             BleManager.retrieveServices(peripheral.id).then((peripheralData) => {
               console.log('Retrieved peripheral services', peripheralData);
@@ -130,11 +130,11 @@ export default class App extends Component {
             });
 
 
-            /*            
+            /*
             BleManager.retrieveServices(peripheral.id).then((peripheralInfo) => {
               BleManager.startNotification(peripheral.id, '00035B03-58E6-07DD-021A-08123A000300', '00035B03-58E6-07DD-021A-08123A000301').then(() => {
                 console.log('Started notification on ' + peripheral.id);
-                this.setTimeout(() => {
+                setTimeout(() => {
 
                 }, 500);
               }).catch((error) => {


### PR DESCRIPTION
While copying the code from 'example' to one of my project, i got 'Reference Error' for the `this.setTimeOut()` method call. It might be safe to call as `setTimeOut`, i think.