### PR TITLE
Provide raw bytes access for advertising data in BleManagerDiscoverPe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,14 @@ The scanning find a new peripheral.
 __Arguments__
 - `id` - `String` - the id of the peripheral
 - `name` - `String` - the name of the peripheral
+- `rssi` - ` Number` - the RSSI value
+- `advertising` - `JSON` - the advertising payload, according to platforms:
+    - [Android] contains the raw `bytes` and  `data` (Base64 encoded string)
+    - [iOS] contains a JSON object with different keys according to [Apple's doc](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/advertisement_data_retrieval_keys?language=objc), here are some examples:
+      - `kCBAdvDataChannel` - `Number`
+      - `kCBAdvDataIsConnectable` - `Number`
+      - `kCBAdvDataLocalName` - `String`
+      - `kCBAdvDataManufacturerData` - `JSON` - contains the raw `bytes` and  `data` (Base64 encoded string)
 
 __Examples__
 ```js

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -283,18 +283,10 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 							String address = device.getAddress();
 
 							if (!peripherals.containsKey(address)) {
-
 								Peripheral peripheral = new Peripheral(device, rssi, scanRecord, reactContext);
 								peripherals.put(device.getAddress(), peripheral);
-
-								try {
-									Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-									WritableMap map = Arguments.fromBundle(bundle);
-									sendEvent("BleManagerDiscoverPeripheral", map);
-								} catch (JSONException ignored) {
-
-								}
-
+								WritableMap map = peripheral.asWritableMap();
+								sendEvent("BleManagerDiscoverPeripheral", map);
 							} else {
 								// this isn't necessary
 								Peripheral peripheral = peripherals.get(address);
@@ -368,13 +360,8 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 		WritableArray map = Arguments.createArray();
 		for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
 			Peripheral peripheral = entry.getValue();
-			try {
-				Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-				WritableMap jsonBundle = Arguments.fromBundle(bundle);
-				map.pushMap(jsonBundle);
-			} catch (JSONException ignored) {
-				callback.invoke("Peripheral json conversion error", null);
-			}
+			WritableMap jsonBundle = peripheral.asWritableMap();
+			map.pushMap(jsonBundle);
 		}
 		callback.invoke(null, map);
 	}
@@ -396,13 +383,8 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			}
 
 			if (peripheral.isConnected() && accept) {
-				try {
-					Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-					WritableMap jsonBundle = Arguments.fromBundle(bundle);
-					map.pushMap(jsonBundle);
-				} catch (JSONException ignored) {
-					callback.invoke("Peripheral json conversion error", null);
-				}
+				WritableMap jsonBundle = peripheral.asWritableMap();
+				map.pushMap(jsonBundle);
 			}
 		}
 		callback.invoke(null, map);

--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -47,13 +47,8 @@ public class LegacyScanManager extends ScanManager {
 								peripheral.updateData(scanRecord);
 							}
 
-							try {
-								Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-								WritableMap map = Arguments.fromBundle(bundle);
-								bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
-							} catch (JSONException ignored) {
-
-							}
+							WritableMap map = peripheral.asWritableMap();
+							bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
 						}
 					});
 				}

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -112,13 +112,8 @@ public class LollipopScanManager extends ScanManager {
 						peripheral.updateData(result.getScanRecord().getBytes());
 					}
 
-					try {
-						Bundle bundle = BundleJSONConverter.convertToBundle(peripheral.asJSONObject());
-						WritableMap map = Arguments.fromBundle(bundle);
-						bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
-					} catch (JSONException ignored) {
-
-					}
+					WritableMap map = peripheral.asWritableMap();
+					bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
 				}
 			});
 		}

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -20,6 +20,7 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONArray;
 
 import java.util.*;
 
@@ -106,24 +107,6 @@ public class Peripheral extends BluetoothGattCallback {
 			Log.d(LOG_TAG, "GATT is null");
 	}
 
-	public JSONObject asJSONObject() {
-
-		JSONObject json = new JSONObject();
-
-		try {
-			json.put("name", device.getName());
-			json.put("id", device.getAddress()); // mac address
-			json.put("advertising", byteArrayToJSON(advertisingData));
-			// TODO real RSSI if we have it, else
-			json.put("rssi", advertisingRSSI);
-		} catch (JSONException e) { // this shouldn't happen
-			e.printStackTrace();
-		}
-
-		return json;
-	}
-
-
 	public WritableMap asWritableMap() {
 
 		WritableMap map = Arguments.createMap();
@@ -208,6 +191,7 @@ public class Peripheral extends BluetoothGattCallback {
 		WritableMap object = Arguments.createMap();
 		object.putString("CDVType", "ArrayBuffer");
 		object.putString("data", Base64.encodeToString(bytes, Base64.NO_WRAP));
+		object.putArray("bytes", BleManager.bytesToWritableArray(bytes));
 		return object;
 	}
 

--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -1,4 +1,5 @@
 #import "CBPeripheral+Extensions.h"
+#import "NSData+Conversion.h"
 
 static char ADVERTISING_IDENTIFER;
 static char ADVERTISEMENT_RSSI_IDENTIFER;
@@ -240,7 +241,8 @@ id dataToArrayBuffer(NSData* data)
 {
   return @{
            @"CDVType" : @"ArrayBuffer",
-           @"data" :[data base64EncodedStringWithOptions:0]
+           @"data" :[data base64EncodedStringWithOptions:0],
+           @"bytes" :[data toArray]
            };
 }
 


### PR DESCRIPTION
Provide raw `bytes` access for advertising data in `BleManagerDiscoverPeripheral` event.

After this patch, the advertising field reported from `BleManagerDiscoverPeripheral` will contain both:
- `data` - base64 encoded string (I still leave it for backward capability)
- `bytes` - raw bytes, array of number

Both iOS and Android are supported and tested.
Thanks!
