### PR TITLE
Make copy of peripherals hashmap to prevent exception while scanning

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -358,7 +358,8 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	public void getDiscoveredPeripherals(Callback callback) {
 		Log.d(LOG_TAG, "Get discovered peripherals");
 		WritableArray map = Arguments.createArray();
-		for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
+		Map <String, Peripheral> peripheralsCopy = new LinkedHashMap<>(peripherals);
+		for (Map.Entry<String, Peripheral> entry : peripheralsCopy.entrySet()) {
 			Peripheral peripheral = entry.getValue();
 			WritableMap jsonBundle = peripheral.asWritableMap();
 			map.pushMap(jsonBundle);
@@ -370,7 +371,8 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	public void getConnectedPeripherals(ReadableArray serviceUUIDs, Callback callback) {
 		Log.d(LOG_TAG, "Get connected peripherals");
 		WritableArray map = Arguments.createArray();
-		for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
+		Map <String, Peripheral> peripheralsCopy = new LinkedHashMap<>(peripherals);
+		for (Map.Entry<String, Peripheral> entry : peripheralsCopy.entrySet()) {
 			Peripheral peripheral = entry.getValue();
 			Boolean accept = false;
 


### PR DESCRIPTION
Scanning while calling `getDiscoveredPeripherals` / `getConnectedPeripherals` can cause a `concurrentModificationException` if the `peripherals` map is simultaneously being iterated in a for loop and items are removed from it in the `scan` method.

Making a copy of the map in these methods prevents this behavior.