### PR TITLE
Remove deprecated rssi usage for iOS

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -519,10 +519,6 @@ RCT_EXPORT_METHOD(read:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUID
     
 }
 
-- (void)peripheralDidUpdateRSSI:(CBPeripheral*)peripheral error:(NSError*)error {
-    [self peripheral: peripheral didReadRSSI: [peripheral RSSI] error: error];
-}
-
 RCT_EXPORT_METHOD(readRSSI:(NSString *)deviceUUID callback:(nonnull RCTResponseSenderBlock)callback)
 {
     NSLog(@"readRSSI");

--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -30,10 +30,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     [dictionary setObject: [self name] forKey: @"name"];
   }
   
-  
-  if ([self RSSI]) {
-    [dictionary setObject: [self RSSI] forKey: @"rssi"];
-  } else if ([self advertisementRSSI]) {
+  if ([self advertisementRSSI]) {
     [dictionary setObject: [self advertisementRSSI] forKey: @"rssi"];
   }
   


### PR DESCRIPTION
Fix issue #183 

Apple has deprecated following APIs from iOS 8:

* `peripheralDidUpdateRSSI:error:` from `CBPeripheralDelegate` (https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/1519083-peripheraldidupdaterssi?language=objc)
* `RSSI` from `CBPeripheral` (https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518869-rssi?language=objc)

Since this library is also targeting iOS 8+, it should be safe to remove them.