### PR TITLE
Breaking change for RN47: remove deprecated createJSModules @Override

### DIFF
--- a/android/src/main/java/it/innove/BleManagerPackage.java
+++ b/android/src/main/java/it/innove/BleManagerPackage.java
@@ -23,7 +23,6 @@ public class BleManagerPackage implements ReactPackage {
 		return  modules;
 	}
 
-	@Override
 	public List<Class<? extends JavaScriptModule>> createJSModules() {
 		return new ArrayList<>();
 	}


### PR DESCRIPTION
Related to issue #195 , this is because of the breaking change for RN47:
* https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

Thanks!