### PR TITLE
Export `getBondedPeripherals` API for Android

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -216,6 +216,22 @@ class BleManager  {
     });
   }
 
+  getBondedPeripherals() {
+    return new Promise((fulfill, reject) => {
+      bleManager.getBondedPeripherals((error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          if (result != null) {
+            fulfill(result);
+          } else {
+            fulfill([]);
+          }
+        }
+      });
+    });
+  }
+
   getDiscoveredPeripherals() {
     return new Promise((fulfill, reject) => {
       bleManager.getDiscoveredPeripherals((error, result) => {

--- a/README.md
+++ b/README.md
@@ -429,6 +429,20 @@ BleManager.getConnectedPeripherals([])
 
 ```
 
+### getBondedPeripherals() [Android only]
+Return the bonded peripherals.
+Returns a `Promise` object.
+
+__Examples__
+```js
+BleManager.getBondedPeripherals([])
+  .then((bondedPeripheralsArray) => {
+    // Each peripheral in returned array will have id and name properties
+    console.log('Bonded peripherals: ' + bondedPeripheralsArray.length);
+  });
+
+```
+
 ### getDiscoveredPeripherals()
 Return the discovered peripherals after a scan.
 Returns a `Promise` object.

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -393,6 +393,19 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
+	public void getBondedPeripherals(Callback callback) {
+		Log.d(LOG_TAG, "Get bonded peripherals");
+		WritableArray map = Arguments.createArray();
+		Set<BluetoothDevice> deviceSet = getBluetoothAdapter().getBondedDevices();
+		for (BluetoothDevice device : deviceSet) {
+			Peripheral peripheral = new Peripheral(device, reactContext);
+			WritableMap jsonBundle = peripheral.asWritableMap();
+			map.pushMap(jsonBundle);
+		}
+		callback.invoke(null, map);
+	}
+
+	@ReactMethod
 	public void removePeripheral(String deviceUUID, Callback callback) {
 		Log.d(LOG_TAG, "Removing from list: " + deviceUUID);
 		Peripheral peripheral = peripherals.get(deviceUUID);


### PR DESCRIPTION
Export `getBondedPeripherals` API for Android, which maps to native API `getBondedDevices`
* https://developer.android.com/reference/android/bluetooth/BluetoothAdapter.html#getBondedDevices()

Tested in Android 6 / 7, and also updated the README.

Currently there's no good solution to retrieve bonded list in iOS, so it's an Android only API for now.
