### PR TITLE
Expose the BleManager instance created by RN

### DIFF
--- a/ios/BleManager.h
+++ b/ios/BleManager.h
@@ -25,4 +25,8 @@
 // For integration with external libraries, advanced use only.
 +(CBCentralManager *)getCentralManager;
 
+// Returns the singleton instance of this class initiated by RN.
+// For integration with external libraries, advanced use only.
++(BleManager *)getInstance;
+
 @end

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -7,6 +7,7 @@
 #import "BLECommandContext.h"
 
 static CBCentralManager *_sharedManager = nil;
+static BleManager * _instance = nil;
 
 @implementation BleManager
 
@@ -34,6 +35,7 @@ bool hasListeners;
         writeQueue = [NSMutableArray array];
         notificationCallbacks = [NSMutableDictionary new];
         stopNotificationCallbacks = [NSMutableDictionary new];
+        _instance = self;
         NSLog(@"BleManager created");
     }
     
@@ -805,6 +807,11 @@ RCT_EXPORT_METHOD(stopNotification:(NSString *)deviceUUID serviceUUID:(NSString*
 +(CBCentralManager *)getCentralManager
 {
     return _sharedManager;
+}
+
++(BleManager *)getInstance
+{
+  return _instance;
 }
 
 @end


### PR DESCRIPTION
This is necessary for advanced integration with external libraries on iOS when the delegate of the manager is changed temporarily.