### PR TITLE
Reject the connect callback when connect fails on ios

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -396,7 +396,14 @@ RCT_EXPORT_METHOD(checkState)
 
 - (void)centralManager:(CBCentralManager *)central didFailToConnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error
 {
-    NSLog(@"Peripheral connection failure: %@. (%@)", peripheral, [error localizedDescription]);
+    NSString *errorStr = [NSString stringWithFormat:@"Peripheral connection failure: %@. (%@)", peripheral, [error localizedDescription]];
+    NSLog(@"%@", errorStr);
+    RCTResponseSenderBlock connectCallback = [connectCallbacks valueForKey:[peripheral uuidAsString]];
+
+    if (connectCallback) {
+        connectCallback(@[errorStr]);
+        [connectCallbacks removeObjectForKey:connectCallback];
+    }
 }
 
 RCT_EXPORT_METHOD(write:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUID  characteristicUUID:(NSString*)characteristicUUID message:(NSArray*)message maxByteSize:(NSInteger)maxByteSize callback:(nonnull RCTResponseSenderBlock)callback)


### PR DESCRIPTION
I noticed that the connect callback is never called on iOS when you receive a delegate call to `didFailToConnectPeripheral`, this fixes that and conforms the iOS and Android APIs.