### PR TITLE
Export createBond API for Android

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -89,6 +89,18 @@ class BleManager  {
     });
   }
 
+  createBond(peripheralId) {
+    return new Promise((fulfill, reject) => {
+      bleManager.createBond(peripheralId, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          fulfill();
+        }
+      });
+    });
+  }
+
   disconnect(peripheralId) {
     return new Promise((fulfill, reject) => {
       bleManager.disconnect(peripheralId, (error) => {

--- a/README.md
+++ b/README.md
@@ -429,6 +429,22 @@ BleManager.getConnectedPeripherals([])
 
 ```
 
+### createBond(peripheralId) [Android only]
+Start the bonding (pairing) process with the remote device.
+Returns a `Promise` object. The promise is resolved when either `new bond successfully created` or `bond already existed`, otherwise it will be rejected.
+
+__Examples__
+```js
+BleManager.createBond(peripheralId)
+  .then(() => {
+    console.log('createBond success or there is already an existing one');
+  })
+  .catch(() => {
+    console.log('fail to bond');
+  })
+
+```
+
 ### getBondedPeripherals() [Android only]
 Return the bonded peripherals.
 Returns a `Promise` object.


### PR DESCRIPTION
This patch contains three changes:
1. expose `createBond` API
2. extract `retrieveOrCreatePeripheral` as an utility method, which is required by both `createBond` and `connect`
3. register broadcast receiver to capture bond state change.

Thanks!