### PR TITLE
Reject and remove pending promises when disconnected

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -404,7 +404,7 @@ RCT_EXPORT_METHOD(checkState)
 
     if (connectCallback) {
         connectCallback(@[errorStr]);
-        [connectCallbacks removeObjectForKey:connectCallback];
+        [connectCallbacks removeObjectForKey:[peripheral uuidAsString]];
     }
 }
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -648,7 +648,7 @@ RCT_EXPORT_METHOD(stopNotification:(NSString *)deviceUUID serviceUUID:(NSString*
     
     if (connectCallback) {
         connectCallback(@[[NSNull null], [peripheral asDictionary]]);
-        [connectCallbacks removeObjectForKey:connectCallback];
+        [connectCallbacks removeObjectForKey:[peripheral uuidAsString]];
     }
     if (hasListeners) {
         [self sendEventWithName:@"BleManagerConnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString]}];

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -746,14 +746,15 @@ RCT_EXPORT_METHOD(stopNotification:(NSString *)deviceUUID serviceUUID:(NSString*
     NSLog(@"Characteristics For Service Discover");
     
     NSString *peripheralUUIDString = [peripheral uuidAsString];
-    RCTResponseSenderBlock retrieveServiceCallback = [retrieveServicesCallbacks valueForKey:peripheralUUIDString];
     NSMutableSet *latch = [retrieveServicesLatches valueForKey:peripheralUUIDString];
     [latch removeObject:service];
     
     if ([latch count] == 0) {
         // Call success callback for connect
+        RCTResponseSenderBlock retrieveServiceCallback = [retrieveServicesCallbacks valueForKey:peripheralUUIDString];
         if (retrieveServiceCallback) {
             retrieveServiceCallback(@[[NSNull null], [peripheral asDictionary]]);
+            [retrieveServicesCallbacks removeObjectForKey:peripheralUUIDString];
         }
         [retrieveServicesLatches removeObjectForKey:peripheralUUIDString];
     }


### PR DESCRIPTION
This PR fixes inconsistencies in how pending promises were never rejected if a peripheral disconnected before a bluetooth operation was completed, making it difficult to reason about program flow and handle sequential bluetooth operations.

Example:
1. Connect to peripheral successfully
2. Call `retrieveServices`
3. Peripheral disconnects
4. The promise returned by `retrieveServices` is never resolved/rejected

This PR rejects all pending promises and removes references to them when a peripheral is disconnected, as well as fixing a few bugs where the promises were never removed in the first place after being resolved.