### PR TITLE
[Android] Reject callbacks when disconnecting and assure connection before attempting some methods

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -123,6 +123,8 @@ public class LollipopScanManager extends ScanManager {
 
 		@Override
 		public void onScanFailed(final int errorCode) {
+            WritableMap map = Arguments.createMap();
+            bleManager.sendEvent("BleManagerStopScan", map);
 		}
 	};
 }

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -252,11 +252,21 @@ public class Peripheral extends BluetoothGattCallback {
 			}
 
 			sendConnectionEvent(device, "BleManagerDisconnectPeripheral");
-
+            List<Callback> callbacks = Arrays.asList(writeCallback, retrieveServicesCallback, readRSSICallback, readCallback, registerNotifyCallback);
+            for (Callback currentCallback : callbacks) {
+                if (currentCallback != null) {
+                    currentCallback.invoke("Device disconnected");
+                }
+            }
 			if (connectCallback != null) {
 				connectCallback.invoke("Connection error");
 				connectCallback = null;
 			}
+            writeCallback = null;
+            readCallback = null;
+            retrieveServicesCallback = null;
+            readRSSICallback = null;
+            registerNotifyCallback = null;
 
 		}
 

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -377,6 +377,9 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	private void setNotify(UUID serviceUUID, UUID characteristicUUID, Boolean notify, Callback callback){
+        if (!isConnected()) {
+            callback.invoke("Device is not connected", null);
+        }
 		Log.d(LOG_TAG, "setNotify");
 
 		if (gatt == null) {
@@ -480,6 +483,9 @@ public class Peripheral extends BluetoothGattCallback {
 
 	public void read(UUID serviceUUID, UUID characteristicUUID, Callback callback) {
 
+        if (!isConnected()) {
+            callback.invoke("Device is not connected", null);
+        }
 		if (gatt == null) {
 			callback.invoke("BluetoothGatt is null", null);
 			return;
@@ -500,6 +506,9 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public void readRSSI(Callback callback) {
+        if (!isConnected()) {
+            callback.invoke("Device is not connected", null);
+        }
 		if (gatt == null) {
 			callback.invoke("BluetoothGatt is null", null);
 			return;
@@ -514,6 +523,9 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public void retrieveServices(Callback callback) {
+        if (!isConnected()) {
+            callback.invoke("Device is not connected", null);
+        }
 		if (gatt == null) {
 			callback.invoke("BluetoothGatt is null", null);
 			return;
@@ -560,6 +572,9 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public void write(UUID serviceUUID, UUID characteristicUUID, byte[] data, Integer maxByteSize, Integer queueSleepTime, Callback callback, int writeType) {
+        if (!isConnected()) {
+            callback.invoke("Device is not connected", null);
+        }
 		if (gatt == null) {
 			callback.invoke("BluetoothGatt is null");
 		} else {


### PR DESCRIPTION
- Reject the promises when the device disconnects (same thing as: https://github.com/innoveit/react-native-ble-manager/pull/220, but for Android) 
- It will assure that one is connected before attempting to run any methods requiring a connected device
- Ignore the `example` folder from being published to npm