### PR TITLE
Remove the unnecessary dep in example/App.js, allow easier testing and

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,19 @@ public class MainApplication extends Application implements ReactApplication {
 - Before write, read or start notification you need to call `retrieveServices` method
 
 ## Example
-Look in the [example](https://github.com/innoveit/react-native-ble-manager/tree/master/example) project.
+The easiest way to test is simple make your AppRegistry point to our example component, like this:
+```javascript
+// in your index.ios.js or index.android.js
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+} from 'react-native';
+import App from 'react-native-ble-manager/example/App' //<-- simply point to the example js! 
+
+AppRegistry.registerComponent('MyAwesomeApp', () => App);
+```
+
+Or, you can still look into the whole [example](https://github.com/innoveit/react-native-ble-manager/tree/master/example) folder for a standalone project.
 
 ## Methods
 

--- a/example/App.js
+++ b/example/App.js
@@ -12,12 +12,10 @@ import {
   PermissionsAndroid,
   ListView,
   ScrollView,
-  AppState
+  AppState,
+  Dimensions,
 } from 'react-native';
-import Dimensions from 'Dimensions';
 import BleManager from 'react-native-ble-manager';
-import TimerMixin from 'react-timer-mixin';
-import reactMixin from 'react-mixin';
 
 const window = Dimensions.get('window');
 const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
@@ -143,7 +141,7 @@ export default class App extends Component {
           console.log('Connected to ' + peripheral.id);
 
 
-          this.setTimeout(() => {
+          setTimeout(() => {
 
             /* Test read current RSSI value
             BleManager.retrieveServices(peripheral.id).then((peripheralData) => {
@@ -162,10 +160,10 @@ export default class App extends Component {
               var bakeCharacteristic = '13333333-3333-3333-3333-333333330003';
               var crustCharacteristic = '13333333-3333-3333-3333-333333330001';
 
-              this.setTimeout(() => {
+              setTimeout(() => {
                 BleManager.startNotification(peripheral.id, service, bakeCharacteristic).then(() => {
                   console.log('Started notification on ' + peripheral.id);
-                  this.setTimeout(() => {
+                  setTimeout(() => {
                     BleManager.write(peripheral.id, service, crustCharacteristic, [0]).then(() => {
                       console.log('Writed NORMAL crust');
                       BleManager.write(peripheral.id, service, bakeCharacteristic, [1,95]).then(() => {
@@ -232,7 +230,6 @@ export default class App extends Component {
     );
   }
 }
-reactMixin(App.prototype, TimerMixin);
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Remove the extra dependencies in `example/App.js`, let it only depends on RN itself. Thus the example project can be easily setup by directly point the `AppRegistry` to this file, like this:
```javascript
import React, { Component } from 'react';
import {
  AppRegistry,
} from 'react-native';
import App from 'react-native-ble-manager/example/App' //<-- simply point to the example js! 

AppRegistry.registerComponent('MyAwesomeApp', () => App);
```
The `README` is also updated.