### PR TITLE
Handle reading of empty value.

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -73,10 +73,10 @@ bool hasListeners;
         }
         return;
     }
-    NSLog(@"Read value [%@]: %@", characteristic.UUID, characteristic.value);
+    NSLog(@"Read value [%@]: (%lu) %@", characteristic.UUID, [characteristic.value length], characteristic.value);
     
     if (readCallback != NULL) {
-        readCallback(@[[NSNull null], [characteristic.value toArray]]);
+        readCallback(@[[NSNull null], ([characteristic.value length] > 0) ? [characteristic.value toArray] : [NSNull null]]);
         [readCallbacks removeObjectForKey:key];
     } else {
         if (hasListeners) {


### PR DESCRIPTION
Calling toArray leads exception for empty characteristic values (backed by _NSZeroData). Such exception cause app crash:
---
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]'
---
To prevent exception, check the value and pass NSNull as result for empty ones.