### PR TITLE
Fix incorrect ios property name "AutheticateSignedWrites", missing "n…

### DIFF
--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -215,7 +215,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
   }
   
   if ((p & CBCharacteristicPropertyAuthenticatedSignedWrites) != 0x0) {
-    [props addObject:@"AutheticateSignedWrites"];
+    [props addObject:@"AuthenticateSignedWrites"];
   }
   
   if ((p & CBCharacteristicPropertyExtendedProperties) != 0x0) {


### PR DESCRIPTION
There is a typo in iOS code, `AutheticateSignedWrite` should be `AuthenticateSignedWrite`.
* line 215 @ CBPeripheral+Extensions.m
```
[props addObject:@"AutheticateSignedWrites"];
```

This will cause inconsistency between iOS and android, and Android names it correctly: 
* line 43 @ Helper.java
```
props.putString("AuthenticateSignedWrites", "AuthenticateSignedWrites");
```
