### PR TITLE
Fix peripherals was mutated while being enumerated (30+ peripheral)

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -260,7 +260,9 @@ RCT_EXPORT_METHOD(getConnectedPeripherals:(NSArray *)serviceUUIDStrings callback
         for(CBPeripheral *peripheral in connectedPeripherals){
             NSDictionary * obj = [peripheral asDictionary];
             [foundedPeripherals addObject:obj];
-            [peripherals addObject:peripheral];
+            @synchronized(peripherals) {
+                [peripherals addObject:peripheral];
+            }
         }
     }
     
@@ -345,7 +347,9 @@ RCT_EXPORT_METHOD(stopScan:(nonnull RCTResponseSenderBlock)callback)
      advertisementData:(NSDictionary *)advertisementData
                   RSSI:(NSNumber *)RSSI
 {
-    [peripherals addObject:peripheral];
+    @synchronized(peripherals) {
+        [peripherals addObject:peripheral];
+    }
     [peripheral setAdvertisementData:advertisementData RSSI:RSSI];
         
     NSLog(@"Discover peripheral: %@", [peripheral name]);
@@ -366,7 +370,9 @@ RCT_EXPORT_METHOD(connect:(NSString *)peripheralUUID callback:(nonnull RCTRespon
             NSArray<CBPeripheral *> *peripheralArray = [manager retrievePeripheralsWithIdentifiers:@[uuid]];
             if([peripheralArray count] > 0){
                 peripheral = [peripheralArray objectAtIndex:0];
-                [peripherals addObject:peripheral];
+                @synchronized(peripherals) {
+                    [peripherals addObject:peripheral];
+                }
                 NSLog(@"Successfull retrieved peripheral with UUID : %@", peripheralUUID);
             }
         } else {


### PR DESCRIPTION
Bug logs:

2018-05-09 17:29:54.809 [fatal][tid:com.facebook.react.BleManagerQueue] Exception '*** Collection <__NSSetM: 0x121e92e60> was mutated while being enumerated.' was thrown while invoking getDiscoveredPeripherals on target BleManager with params (
    14229
)
callstack: (
    0   CoreFoundation                      0x0000000181ee2da4 <redacted> + 252
    1   libobjc.A.dylib                     0x000000018109c5ec objc_exception_throw + 56
    2   CoreFoundation                      0x0000000181ee23c0 <redacted> + 0
    3   KfRn                                0x0000000100c5f05c -[BleManager getDiscoveredPeripherals:] + 364
    4   CoreFoundation                      0x0000000181eea580 <redacted> + 144
    5   CoreFoundation                      0x0000000181dc9748 <redacted> + 284
    6   CoreFoundation                      0x0000000181dce56c <redacted> + 60
    7   KfRn                                0x0000000100d01044 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
    8   KfRn                                0x0000000100da5d50 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
    9   KfRn                                0x0000000100da58e0 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
    10  KfRn                                0x0000000100da5850 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
    11  libdispatch.dylib                   0x0000000101a89260 _dispatch_call_block_and_release + 24
    12  libdispatch.dylib                   0x0000000101a89220 _dispatch_client_callout + 16
    13  libdispatch.dylib                   0x0000000101a97e80 _dispatch_queue_serial_drain + 768
    14  libdispatch.dylib                   0x0000000101a8c730 _dispatch_queue_invoke + 328
    15  libdispatch.dylib                   0x0000000101a98dd8 _dispatch_root_queue_drain_deferred_wlh + 352
    16  libdispatch.dylib                   0x0000000101a9febc _dispatch_workloop_worker_thread + 676
    17  libsystem_pthread.dylib             0x0000000181b07e70 _pthread_wqthread + 860
    18  libsystem_pthread.dylib             0x0000000181b07b08 start_wqthread + 4