### PR TITLE
Better advertising data (iOS and Android)

### DIFF
--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -103,12 +103,12 @@ public class LollipopScanManager extends ScanManager {
                     Peripheral peripheral = null;
 
 					if (!bleManager.peripherals.containsKey(address)) {
-						peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord().getBytes(), reactContext);
+						peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord(), reactContext);
 						bleManager.peripherals.put(address, peripheral);
 					} else {
 						peripheral = bleManager.peripherals.get(address);
 						peripheral.updateRssi(result.getRssi());
-						peripheral.updateData(result.getScanRecord().getBytes());
+						peripheral.updateData(result.getScanRecord());
 					}
 
 					WritableMap map = peripheral.asWritableMap();

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -7,7 +7,9 @@ import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
+import android.bluetooth.le.ScanRecord;
 import android.os.Build;
+import android.os.ParcelUuid;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;
@@ -35,7 +37,8 @@ public class Peripheral extends BluetoothGattCallback {
 	private static final String CHARACTERISTIC_NOTIFICATION_CONFIG = "00002902-0000-1000-8000-00805f9b34fb";
 
 	private final BluetoothDevice device;
-	private byte[] advertisingData;
+	private ScanRecord advertisingData;
+	private byte[] advertisingDataBytes;
 	private int advertisingRSSI;
 	private boolean connected = false;
 	private ReactContext reactContext;
@@ -53,12 +56,18 @@ public class Peripheral extends BluetoothGattCallback {
 	private List<byte[]> writeQueue = new ArrayList<>();
 
 	public Peripheral(BluetoothDevice device, int advertisingRSSI, byte[] scanRecord, ReactContext reactContext) {
+		this.device = device;
+		this.advertisingRSSI = advertisingRSSI;
+		this.advertisingDataBytes = scanRecord;
+		this.reactContext = reactContext;
+	}
 
+	public Peripheral(BluetoothDevice device, int advertisingRSSI, ScanRecord scanRecord, ReactContext reactContext) {
 		this.device = device;
 		this.advertisingRSSI = advertisingRSSI;
 		this.advertisingData = scanRecord;
+		this.advertisingDataBytes = scanRecord.getBytes();
 		this.reactContext = reactContext;
-
 	}
 
 	public Peripheral(BluetoothDevice device, ReactContext reactContext) {
@@ -112,14 +121,38 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public WritableMap asWritableMap() {
-
 		WritableMap map = Arguments.createMap();
+		WritableMap advertising = Arguments.createMap();
 
 		try {
 			map.putString("name", device.getName());
 			map.putString("id", device.getAddress()); // mac address
-			map.putMap("advertising", byteArrayToWritableMap(advertisingData));
 			map.putInt("rssi", advertisingRSSI);
+
+			advertising.putMap("manufacturerData", byteArrayToWritableMap(advertisingDataBytes));
+			advertising.putBoolean("isConnectable", true);
+			advertising.putString("localName", device.getName());
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && advertisingData != null) {
+				WritableArray serviceUuids = Arguments.createArray();
+				if (advertisingData.getServiceUuids() != null && advertisingData.getServiceUuids().size() != 0) {
+					for (ParcelUuid uuid : advertisingData.getServiceUuids()) {
+						serviceUuids.pushString(UUIDHelper.uuidToString(uuid.getUuid()));
+					}
+				}
+				advertising.putArray("serviceUuids", serviceUuids);
+
+				WritableMap serviceData = Arguments.createMap();
+				if (advertisingData.getServiceData() != null) {
+					for (Map.Entry<ParcelUuid, byte[]> entry : advertisingData.getServiceData().entrySet()) {
+						serviceData.putMap(UUIDHelper.uuidToString(((ParcelUuid) entry.getKey()).getUuid()), byteArrayToWritableMap((byte[]) entry.getValue()));
+					}
+				}
+
+				advertising.putInt("txPowerLevel", advertisingData.getTxPowerLevel());
+			}
+
+			map.putMap("advertising", advertising);
 		} catch (Exception e) { // this shouldn't happen
 			e.printStackTrace();
 		}
@@ -128,7 +161,6 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public WritableMap asWritableMap(BluetoothGatt gatt) {
-
 		WritableMap map = asWritableMap();
 
 		WritableArray servicesArray = Arguments.createArray();
@@ -139,7 +171,6 @@ public class Peripheral extends BluetoothGattCallback {
 				BluetoothGattService service = it.next();
 				WritableMap serviceMap = Arguments.createMap();
 				serviceMap.putString("uuid", UUIDHelper.uuidToString(service.getUuid()));
-
 
 				for (Iterator<BluetoothGattCharacteristic> itCharacteristic = service.getCharacteristics().iterator(); itCharacteristic.hasNext(); ) {
 					BluetoothGattCharacteristic characteristic = itCharacteristic.next();
@@ -282,7 +313,11 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public void updateData(byte[] data) {
-		advertisingData = data;
+		advertisingDataBytes = data;
+	}
+
+	public void updateData(ScanRecord scanRecord) {
+		advertisingData = scanRecord;
 	}
 
 	public int unsignedToBytes(byte b) {

--- a/ios/BleManager.xcodeproj/project.pbxproj
+++ b/ios/BleManager.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -283,6 +284,7 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/BleManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/BleManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -82,7 +82,28 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
 - (NSDictionary *) serializableAdvertisementData: (NSDictionary *) advertisementData {
   
   NSMutableDictionary *dict = [advertisementData mutableCopy];
-  
+
+  // Rename 'local name' key
+  NSObject *localName = [dict objectForKey:CBAdvertisementDataLocalNameKey];
+  if (localName) {
+    [dict setObject:[dict objectForKey:CBAdvertisementDataLocalNameKey] forKey:@"localName"];
+    [dict removeObjectForKey:CBAdvertisementDataLocalNameKey];
+  }
+
+  // Rename 'isConnectable' key
+  NSObject *isConnectable = [dict objectForKey:CBAdvertisementDataIsConnectable];
+  if (isConnectable) {
+    [dict setObject:[dict objectForKey:CBAdvertisementDataIsConnectable] forKey:@"isConnectable"];
+    [dict removeObjectForKey:CBAdvertisementDataIsConnectable];
+  }
+
+  // Rename 'power level' key
+  NSObject *powerLevel = [dict objectForKey:CBAdvertisementDataTxPowerLevelKey];
+  if (powerLevel) {
+    [dict setObject:[dict objectForKey:CBAdvertisementDataTxPowerLevelKey] forKey:@"txPowerLevel"];
+    [dict removeObjectForKey:CBAdvertisementDataTxPowerLevelKey];
+  }
+
   // Service Data is a dictionary of CBUUID and NSData
   // Convert to String keys with Array Buffer values
   NSMutableDictionary *serviceData = [dict objectForKey:CBAdvertisementDataServiceDataKey];
@@ -93,10 +114,14 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
       [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
       [serviceData removeObjectForKey:key];
     }
+
+    // replace the Service Data object
+    [dict setObject:[dict objectForKey:CBAdvertisementDataServiceDataKey] forKey:@"serviceData"];
+    [dict removeObjectForKey:CBAdvertisementDataServiceDataKey];
   }
-  
+
   // Create a new list of Service UUIDs as Strings instead of CBUUIDs
-  NSMutableArray *serviceUUIDs = [dict objectForKey:CBAdvertisementDataServiceUUIDsKey];
+  NSMutableArray *serviceUUIDs = [dict objectForKey: CBAdvertisementDataServiceUUIDsKey];
   NSMutableArray *serviceUUIDStrings;
   if (serviceUUIDs) {
     serviceUUIDStrings = [[NSMutableArray alloc] initWithCapacity:serviceUUIDs.count];
@@ -107,8 +132,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     
     // replace the UUID list with list of strings
     [dict removeObjectForKey:CBAdvertisementDataServiceUUIDsKey];
-    [dict setObject:serviceUUIDStrings forKey:CBAdvertisementDataServiceUUIDsKey];
-    
+    [dict setObject:serviceUUIDStrings forKey:@"serviceUUIDs"];
   }
   
   // Solicited Services UUIDs is an array of CBUUIDs, convert into Strings
@@ -124,13 +148,30 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     
     // replace the UUID list with list of strings
     [dict removeObjectForKey:CBAdvertisementDataSolicitedServiceUUIDsKey];
-    [dict setObject:solicitiedServiceUUIDStrings forKey:CBAdvertisementDataSolicitedServiceUUIDsKey];
+    [dict setObject:solicitiedServiceUUIDStrings forKey:@"solicitedServiceUUIDs"];
+  }
+
+  // Overflow Services UUIDs is an array of CBUUIDs, convert into Strings
+  NSMutableArray *overflowServiceUUIDs = [dict objectForKey:CBAdvertisementDataOverflowServiceUUIDsKey];
+  NSMutableArray *overflowServiceUUIDStrings;
+  if (overflowServiceUUIDs) {
+    // NSLog(@"%@", overflowServiceUUIDs);
+    overflowServiceUUIDStrings = [[NSMutableArray alloc] initWithCapacity:overflowServiceUUIDs.count];
+
+    for (CBUUID *uuid in overflowServiceUUIDs) {
+      [overflowServiceUUIDStrings addObject:[uuid UUIDString]];
+    }
+
+    // replace the UUID list with list of strings
+    [dict removeObjectForKey:CBAdvertisementDataOverflowServiceUUIDsKey];
+    [dict setObject:overflowServiceUUIDStrings forKey:@"overflowServiceUUIDs"];
   }
   
   // Convert the manufacturer data
   NSData *mfgData = [dict objectForKey:CBAdvertisementDataManufacturerDataKey];
   if (mfgData) {
-    [dict setObject:dataToArrayBuffer([dict objectForKey:CBAdvertisementDataManufacturerDataKey]) forKey:CBAdvertisementDataManufacturerDataKey];
+    [dict setObject:dataToArrayBuffer([dict objectForKey:CBAdvertisementDataManufacturerDataKey]) forKey:@"manufacturerData"];
+    [dict removeObjectForKey:CBAdvertisementDataManufacturerDataKey];
   }
   
   return dict;


### PR DESCRIPTION
I unified the advertising data object, so the "advertising" object in a scan result should look pretty much the same between iOS and Android.

Especially nice since the Android part was quite lacking in this regard.

You can test the changes by scanning for BLE devices around you and comparing the scan result, or I can add examples later if needed.