### PR TITLE
remove error when bluetooth disabled in stopScan.

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -163,7 +163,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			return;
 		}
 		if (!getBluetoothAdapter().isEnabled()) {
-			callback.invoke("Bluetooth not enabled");
+			callback.invoke();
 			return;
 		}
 		scanManager.stopScan(callback);


### PR DESCRIPTION
Android report "Bluetooth not enabled" error, but iOS didn't, this will cause 'Possible Unhandled Promise Rejection' in react-native.