### PR TITLE
BleManager.retrieveServices(id) always returns null

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -564,7 +564,6 @@ public class Peripheral extends BluetoothGattCallback {
 		}
 		this.retrieveServicesCallback = callback;
 		gatt.discoverServices();
-		callback.invoke();
 	}
 
 


### PR DESCRIPTION
#338 introduced a change to Peripheral.retrieveServices(callback) so that callback is callback is always invoked instead of letting gatt.discoverServices() invoke the callback as it was until now.

this results in the BleMananger.retrieveServices(id) to always resolve to null.
