### PR TITLE
Make Android > Lollipop use name from advertising record as localName

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -73,6 +73,7 @@ public class Peripheral extends BluetoothGattCallback {
 	public Peripheral(BluetoothDevice device, int advertisingRSSI, ScanRecord scanRecord, ReactContext reactContext) {
 		this.device = device;
 		this.advertisingRSSI = advertisingRSSI;
+		this.advertisingData = scanRecord;
 		this.advertisingDataBytes = scanRecord.getBytes();;
 		this.reactContext = reactContext;
 	}
@@ -155,9 +156,13 @@ public class Peripheral extends BluetoothGattCallback {
 			map.putString("id", device.getAddress()); // mac address
 			map.putInt("rssi", advertisingRSSI);
 
+			if (advertisingData != null)
+				advertising.putString("localName", advertisingData.getDeviceName());
+			else
+				advertising.putString("localName", device.getName());
+
 			advertising.putMap("manufacturerData", byteArrayToWritableMap(advertisingDataBytes));
 			advertising.putBoolean("isConnectable", true);
-			advertising.putString("localName", device.getName());
 
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && advertisingData != null) {
 				WritableArray serviceUuids = Arguments.createArray();

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -157,7 +157,7 @@ public class Peripheral extends BluetoothGattCallback {
 			map.putInt("rssi", advertisingRSSI);
 
 			if (advertisingData != null)
-				advertising.putString("localName", advertisingData.getDeviceName());
+				advertising.putString("localName", advertisingData.getDeviceName().replace("\0", ""));
 			else
 				advertising.putString("localName", device.getName());
 


### PR DESCRIPTION
Make Android in version higher than Lollipop take localName from advertising record as in IOS. When it's not there localName is same as name in Android so we don't even need that field.

Fix in Android > Lollipop take advertisingData from scanRecord when new peripheral found. Then in react native we can see advertising -> services and advertising-> localName