### PR TITLE
Fix: The app crashes when a characteristic with 0x value is discovered

### DIFF
--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -151,7 +151,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
       [characteristicDictionary setObject:[[service UUID] UUIDString] forKey:@"service"];
       [characteristicDictionary setObject:[[characteristic UUID] UUIDString] forKey:@"characteristic"];
       
-      if ([characteristic value]) {
+      if ([characteristic value] && [[characteristic value] length] > 0) {
         [characteristicDictionary setObject:dataToArrayBuffer([characteristic value]) forKey:@"value"];
       }
       if ([characteristic properties]) {


### PR DESCRIPTION
I experienced a crash on iOS 11.4 in `dataToArrayBuffer` when connecting to a BLE peripheral. This peripheral has a characteristic with value 0x (byte array of length 0).

When `data` is empty, `[data toArray]` returns nil and causes a crash. See error below.

`*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]'`

This fixes the problem for me. Alternatively, `dataToArrayBuffer` can updated to support empty data. If someone knows NSData well, this could be another solution.