### PR TITLE
check scanManager before "scan" and "stopScan"

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -151,7 +151,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			}
 		}
 
-		scanManager.scan(serviceUUIDs, scanSeconds, options, callback);
+		if(scanManager!=null) scanManager.scan(serviceUUIDs, scanSeconds, options, callback);
 	}
 
 	@ReactMethod
@@ -166,7 +166,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			callback.invoke();
 			return;
 		}
-		scanManager.stopScan(callback);
+		if(scanManager!=null) scanManager.stopScan(callback);
 	}
 
 	@ReactMethod


### PR DESCRIPTION
prevent crash with FATAL EXCEPTION: mqt_native_modules when wrongly call "scan" before "start"