### PR TITLE
Selective service retrieval

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -44,9 +44,9 @@ class BleManager  {
     });
   }
 
-  retrieveServices(peripheralId) {
+  retrieveServices(peripheralId, services) {
     return new Promise((fulfill, reject) => {
-      bleManager.retrieveServices(peripheralId, (error, peripheral) => {
+      bleManager.retrieveServices(peripheralId, services, (error, peripheral) => {
         if (error) {
           reject(error);
         } else {

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Returns a `Promise` object.
 
 __Arguments__
 - `peripheralId` - `String` - the id/mac address of the peripheral.
+- `serviceUUIDs` - `String[]` - [iOS only] only retrieve these services.
 
 __Examples__
 ```js

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -306,7 +306,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-	public void retrieveServices(String deviceUUID, Callback callback) {
+	public void retrieveServices(String deviceUUID, String[] services, Callback callback) {
 		Log.d(LOG_TAG, "Retrieve services from: " + deviceUUID);
 		Peripheral peripheral = peripherals.get(deviceUUID);
 		if (peripheral != null) {

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -579,19 +579,30 @@ RCT_EXPORT_METHOD(readRSSI:(NSString *)deviceUUID callback:(nonnull RCTResponseS
     
 }
 
-RCT_EXPORT_METHOD(retrieveServices:(NSString *)deviceUUID callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(retrieveServices:(NSString *)deviceUUID services:(NSArray<NSString *> *)services callback:(nonnull RCTResponseSenderBlock)callback)
 {
-    NSLog(@"retrieveServices");
+    NSLog(@"retrieveServices %@", services);
     
     CBPeripheral *peripheral = [self findPeripheralByUUID:deviceUUID];
     
     if (peripheral && peripheral.state == CBPeripheralStateConnected) {
         [retrieveServicesCallbacks setObject:callback forKey:[peripheral uuidAsString]];
-        [peripheral discoverServices:nil];
+        
+        NSMutableArray<CBUUID *> *uuids = [NSMutableArray new];
+        for ( NSString *string in services ) {
+            CBUUID *uuid = [CBUUID UUIDWithString:string];
+            [uuids addObject:uuid];
+        }
+        
+        if ( uuids.count > 0 ) {
+            [peripheral discoverServices:uuids];
+        } else {
+            [peripheral discoverServices:nil];
+        }
+        
     } else {
         callback(@[@"Peripheral not found or not connected"]);
     }
-    
 }
 
 RCT_EXPORT_METHOD(startNotification:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUID  characteristicUUID:(NSString*)characteristicUUID callback:(nonnull RCTResponseSenderBlock)callback)


### PR DESCRIPTION
Hi there,

Thanks for the excellent library!  This PR adds iOS only support for selective service discovery/retrieval by simply passing the optional `services` parameter through to [[discoverServices:serviceUUIDs?]](https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518706-discoverservices). 

Utilizing this parameter can lead to a dramatic reduction in time between initiating a connection and reading or writing a known characteristic.  Mileage will vary by GATT table, in our very specific case this reduced times from about ~3s to ~0.5s.

I'm not the best native android dev, but as far as I can tell this isn't supported by [BluetoothGATT](https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#discoverServices()) on Android.  Happy to be proved wrong or hear of any workarounds.  

Cheers,   