### PR TITLE
Fix retrieveServices on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ BleManager.requestMTU('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', 512)
 });
 ```
 
-### retrieveServices(peripheralId)
+### retrieveServices(peripheralId[, serviceUUIDs])
 Retrieve the peripheral's services and characteristics.
 Returns a `Promise` object.
 
@@ -473,7 +473,7 @@ BleManager.retrieveServices('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX')
   .then((peripheralInfo) => {
     // Success code
     console.log('Peripheral info:', peripheralInfo);
-  });  
+  });
 ```
 
 ### refreshCache(peripheralId) [Android only]
@@ -492,7 +492,7 @@ BleManager.refreshCache('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX')
   })
   .cache((error) => {
     console.error(error)
-  }); 
+  });
 ```
 
 

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -306,7 +306,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-	public void retrieveServices(String deviceUUID, String[] services, Callback callback) {
+	public void retrieveServices(String deviceUUID, ReadableArray services, Callback callback) {
 		Log.d(LOG_TAG, "Retrieve services from: " + deviceUUID);
 		Peripheral peripheral = peripherals.get(deviceUUID);
 		if (peripheral != null) {


### PR DESCRIPTION
After #398 , `retrieveServices` seems not working at all on Android. 

Following code is introduced in that p-r:

```java
@ReactMethod
public void retrieveServices(String deviceUUID, String[] services, Callback callback) {
```
`String[]` here must be `ReadableArray`, otherwise compile will success but will not work with runtime error. 

This p-r just fix it. I hope this will be released soon.