### PR TITLE
Fill the internal peripherals map in the getConnectedPeripherals method

### DIFF
--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -25,7 +25,6 @@ public class LegacyScanManager extends ScanManager {
 	private BluetoothAdapter.LeScanCallback mLeScanCallback =
 			new BluetoothAdapter.LeScanCallback() {
 
-
 				@Override
 				public void onLeScan(final BluetoothDevice device, final int rssi,
 									 final byte[] scanRecord) {
@@ -33,17 +32,8 @@ public class LegacyScanManager extends ScanManager {
 						@Override
 						public void run() {
 							Log.i(bleManager.LOG_TAG, "DiscoverPeripheral: " + device.getName());
-							String address = device.getAddress();
-							Peripheral peripheral;
 
-							if (!bleManager.peripherals.containsKey(address)) {
-								peripheral = new Peripheral(device, rssi, scanRecord, reactContext);
-								bleManager.peripherals.put(device.getAddress(), peripheral);
-							} else {
-								peripheral = bleManager.peripherals.get(address);
-								peripheral.updateRssi(rssi);
-								peripheral.updateData(scanRecord);
-							}
+                            Peripheral peripheral = bleManager.savePeripheral(device, rssi, scanRecord);
 
 							WritableMap map = peripheral.asWritableMap();
 							bleManager.sendEvent("BleManagerDiscoverPeripheral", map);

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -8,11 +8,9 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.ParcelUuid;
 import android.util.Log;
 import com.facebook.react.bridge.*;
-import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -99,17 +97,8 @@ public class LollipopScanManager extends ScanManager {
 				@Override
 				public void run() {
 					Log.i(bleManager.LOG_TAG, "DiscoverPeripheral: " + result.getDevice().getName());
-					String address = result.getDevice().getAddress();
-                    Peripheral peripheral = null;
 
-					if (!bleManager.peripherals.containsKey(address)) {
-						peripheral = new Peripheral(result.getDevice(), result.getRssi(), result.getScanRecord(), reactContext);
-						bleManager.peripherals.put(address, peripheral);
-					} else {
-						peripheral = bleManager.peripherals.get(address);
-						peripheral.updateRssi(result.getRssi());
-						peripheral.updateData(result.getScanRecord());
-					}
+                    Peripheral peripheral = bleManager.savePeripheral(result.getDevice(), result.getRssi(), result.getScanRecord());
 
 					WritableMap map = peripheral.asWritableMap();
 					bleManager.sendEvent("BleManagerDiscoverPeripheral", map);

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -27,11 +27,14 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONArray;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.facebook.react.common.ReactConstants.TAG;
@@ -74,7 +77,7 @@ public class Peripheral extends BluetoothGattCallback {
 		this.device = device;
 		this.advertisingRSSI = advertisingRSSI;
 		this.advertisingData = scanRecord;
-		this.advertisingDataBytes = scanRecord.getBytes();;
+		this.advertisingDataBytes = scanRecord.getBytes();
 		this.reactContext = reactContext;
 	}
 
@@ -110,7 +113,7 @@ public class Peripheral extends BluetoothGattCallback {
 					Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class, BluetoothGattCallback.class, Integer.class);
 					m.setAccessible(true);
 					Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
-					gatt = (BluetoothGatt)m.invoke(device, activity, false, this, transport);
+					gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
 				} catch (Exception e) {
 					e.printStackTrace();
 					Log.d(TAG, " Catch to call normal connection");
@@ -118,9 +121,9 @@ public class Peripheral extends BluetoothGattCallback {
 							this);
 				}
 			}
-			onConnectionStateChange(gatt, 0,BluetoothGatt.STATE_CONNECTED);
+			onConnectionStateChange(gatt, 0, BluetoothGatt.STATE_CONNECTED);
 
-			} else {
+		} else {
 			if (gatt != null) {
 				callback.invoke();
 			} else {
@@ -264,8 +267,8 @@ public class Peripheral extends BluetoothGattCallback {
 	static WritableMap byteArrayToWritableMap(byte[] bytes) throws JSONException {
 		WritableMap object = Arguments.createMap();
 		object.putString("CDVType", "ArrayBuffer");
-		object.putString("data", Base64.encodeToString(bytes, Base64.NO_WRAP));
-		object.putArray("bytes", BleManager.bytesToWritableArray(bytes));
+		object.putString("data", bytes != null ? Base64.encodeToString(bytes, Base64.NO_WRAP) : null);
+		object.putArray("bytes", bytes != null ? BleManager.bytesToWritableArray(bytes) : null);
 		return object;
 	}
 
@@ -310,8 +313,7 @@ public class Peripheral extends BluetoothGattCallback {
 				public void run() {
 					try {
 						gatt.discoverServices();
-					}
-					catch (NullPointerException e) {
+					} catch (NullPointerException e) {
 						Log.d(BleManager.LOG_TAG, "onConnectionStateChange connected but gatt of Run method was null");
 					}
 				}
@@ -607,21 +609,19 @@ public class Peripheral extends BluetoothGattCallback {
 	}
 
 	public void refreshCache(Callback callback) {
-        try {
-            Method localMethod = gatt.getClass().getMethod("refresh", new Class[0]);
-            if (localMethod != null) {
-                boolean res = ((Boolean) localMethod.invoke(gatt, new Object[0])).booleanValue();
-                callback.invoke(null, res);
-            } else {
-                callback.invoke("Could not refresh cache for device.");
-            }
-        }
-        catch (Exception localException) {
-            Log.e(TAG, "An exception occured while refreshing device");
-            callback.invoke(localException.getMessage());
-        }
-
-    }
+		try {
+			Method localMethod = gatt.getClass().getMethod("refresh", new Class[0]);
+			if (localMethod != null) {
+				boolean res = ((Boolean) localMethod.invoke(gatt, new Object[0])).booleanValue();
+				callback.invoke(null, res);
+			} else {
+				callback.invoke("Could not refresh cache for device.");
+			}
+		} catch (Exception localException) {
+			Log.e(TAG, "An exception occured while refreshing device");
+			callback.invoke(localException.getMessage());
+		}
+	}
 
 	public void retrieveServices(Callback callback) {
 		if (!isConnected()) {


### PR DESCRIPTION
The goal was to be able to use or disconnect from an already connected BLE device after an app restart/reload (without scanning) on Android. Previously these always resulted in a "Peripheral not found" error.

- Changed the map's visibility to private and moved Peripheral creation logic inside BleManager to make it cleaner. And used this savePeripheral method inside getConnectedPeripherals. 
- Added synchronized blocks for every modification of the map. These might not be necessary but a LinkedHashMap does not guarantee thread safety.
- Other changes are auto-formatting and import related.

These related issues may get fixed: #276  and #318 