### PR TITLE
Removing gatt.disconnect in the disconnect

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -125,9 +125,9 @@ class BleManager  {
     });
   }
 
-  disconnect(peripheralId) {
+  disconnect(peripheralId, force=true) {
     return new Promise((fulfill, reject) => {
-      bleManager.disconnect(peripheralId, (error) => {
+      bleManager.disconnect(peripheralId, force, (error) => {
         if (error) {
           reject(error);
         } else {

--- a/README.md
+++ b/README.md
@@ -224,12 +224,19 @@ BleManager.connect('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX')
   });
 ```
 
-### disconnect(peripheralId)
+### disconnect(peripheralId, force)
 Disconnect from a peripheral.
 Returns a `Promise` object.
 
 __Arguments__
 - `peripheralId` - `String` - the id/mac address of the peripheral to disconnect.
+- `force` - `boolean` - [Android only] defaults to true, if true force closes gatt
+                        connection and send the BleManagerDisconnectPeripheral
+                        event immediately to Javascript, else disconnects the
+                        connection and waits for [`disconnected state`](https://developer.android.com/reference/android/bluetooth/BluetoothProfile#STATE_DISCONNECTED) to
+                        [`close the gatt connection`](https://developer.android.com/reference/android/bluetooth/BluetoothGatt#close())
+                        and then sends the BleManagerDisconnectPeripheral to the
+                        Javascript
 
 __Examples__
 ```js

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -245,12 +245,12 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-	public void disconnect(String peripheralUUID, Callback callback) {
+	public void disconnect(String peripheralUUID, boolean force, Callback callback) {
 		Log.d(LOG_TAG, "Disconnect from: " + peripheralUUID);
 
 		Peripheral peripheral = peripherals.get(peripheralUUID);
 		if (peripheral != null) {
-			peripheral.disconnect();
+			peripheral.disconnect(force);
 			callback.invoke();
 		} else
 			callback.invoke("Peripheral not found");

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -134,15 +134,18 @@ public class Peripheral extends BluetoothGattCallback {
 		}
 	}
 
-	public void disconnect() {
+	public void disconnect(boolean force) {
 		connectCallback = null;
 		connected = false;
 		if (gatt != null) {
 			try {
-				gatt.close();
-				gatt = null;
+				gatt.disconnect();
+				if (force) {
+					gatt.close();
+					gatt = null;
+					sendConnectionEvent(device, "BleManagerDisconnectPeripheral", BluetoothGatt.GATT_SUCCESS);
+				}
 				Log.d(BleManager.LOG_TAG, "Disconnect");
-				sendConnectionEvent(device, "BleManagerDisconnectPeripheral", BluetoothGatt.GATT_SUCCESS);
 			} catch (Exception e) {
 				sendConnectionEvent(device, "BleManagerDisconnectPeripheral", BluetoothGatt.GATT_FAILURE);
 				Log.d(BleManager.LOG_TAG, "Error on disconnect", e);
@@ -334,6 +337,7 @@ public class Peripheral extends BluetoothGattCallback {
 				connected = false;
 
 				if (gatt != null) {
+					gatt.disconnect();
 					gatt.close();
 					this.gatt = null;
 				}

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -139,7 +139,6 @@ public class Peripheral extends BluetoothGattCallback {
 		connected = false;
 		if (gatt != null) {
 			try {
-				gatt.disconnect();
 				gatt.close();
 				gatt = null;
 				Log.d(BleManager.LOG_TAG, "Disconnect");
@@ -335,7 +334,6 @@ public class Peripheral extends BluetoothGattCallback {
 				connected = false;
 
 				if (gatt != null) {
-					gatt.disconnect();
 					gatt.close();
 					this.gatt = null;
 				}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,73 @@
+declare module 'react-native-ble-manager' {
+	
+	export interface Peripheral {
+		id: string;
+		rssi: number;
+		name?: string;
+		advertising: AdvertisingData;
+	}
+
+	export interface AdvertisingData {
+		isConnectable?: boolean;
+		localName?: string;
+		manufacturerData?: any;
+		serviceUUIDs?: string[];
+		txPowerLevel?: number;
+	}
+
+	export interface StartOptions {
+		showAlert?: boolean
+		restoreIdentifierKey?: string
+		forceLegacy?: boolean
+	}
+
+	export function start(options?: StartOptions): Promise<void>
+
+	export interface ScanOptions {
+		numberOfMatches?: number;
+		matchMode?: number;
+		scanMode?: number;
+    }
+    
+	export function scan(serviceUUIDs: string[], seconds: number, allowDuplicates?: boolean, options?: ScanOptions): Promise<void>;
+	export function stopScan(): Promise<void>;
+	export function connect(peripheralID: string): Promise<void>
+	export function disconnect(peripheralID: string): Promise<void>
+	export function checkState(): void;
+	export function startNotification(peripheralID: string, serviceUUID: string, characteristicUUID: string): Promise<void>
+    export function stopNotification(peripheralID: string, serviceUUID: string, characteristicUUID: string): Promise<void>
+    
+	export function read(peripheralID: string, serviceUUID: string, characteristicUUID: string): Promise<any>
+	export function write(peripheralID: string, serviceUUID: string, characteristicUUID: string, data: any, maxByteSize?: number): Promise<void>
+	export function writeWithoutResponse(peripheralID: string, serviceUUID: string, characteristicUUID: string, data: any, maxByteSize?: number, queueSleepTime?: number): Promise<void>
+
+	export function readRSSI(peripheralID: string): Promise<void>
+
+	export function getConnectedPeripherals(serviceUUIDs: string[]): Promise<void>
+	export function getDiscoveredPeripherals(): Promise<any[]>
+	export function isPeripheralConnected(peripheralID: string, serviceUUIDs: string[]): Promise<boolean>
+
+	// [Android only API 21+]
+	export enum ConnectionPriority {
+		balanced = 0,
+		high = 1,
+		low = 2
+	}
+	export function requestConnectionPriority(peripheralID: string, connectionPriority: ConnectionPriority): Promise<void>
+	/// Android only
+	export function enableBluetooth(): Promise<void>
+	// [Android only]
+	export function refreshCache(peripheralID: string): Promise<void>
+	// [Android only API 21+]
+	export function requestMTU(peripheralID: string, mtu: number): Promise<void>
+
+	export function createBond(peripheralID: string): Promise<void>
+	export function removeBond(peripheralID: string): Promise<void>
+	export function getBondedPeripherals(): Promise<void>
+	export function removePeripheral(peripheralID: string): Promise<void>
+
+	export interface PeripheralInfo {
+
+	}
+	export function retrieveServices(peripheralID: string, serviceUUIDs?: string[]): Promise<PeripheralInfo>
+}

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -402,7 +402,7 @@ RCT_EXPORT_METHOD(connect:(NSString *)peripheralUUID callback:(nonnull RCTRespon
     }
 }
 
-RCT_EXPORT_METHOD(disconnect:(NSString *)peripheralUUID  callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(disconnect:(NSString *)peripheralUUID force:(bool)force callback:(nonnull RCTResponseSenderBlock)callback)
 {
     CBPeripheral *peripheral = [self findPeripheralByUUID:peripheralUUID];
     if (peripheral) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.5.6",
   "description": "A BLE module for react native.",
   "main": "BleManager",
+  "types": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/innoveit/react-native-ble-manager.git"


### PR DESCRIPTION
Reason gatt.disconnect would trigger an
onConnectionStateChange, but an immediate
gatt.close would unregisterApp would remove
all the needed resources notify the BluetoothGattCallback
object.

In short there is no need of calling disconnect if close
is being called immediately

Check https://stackoverflow.com/questions/23110295/difference-between-close-and-disconnect

Also check the below stackTrace - leading to an exception which could be avoided

```
D/BluetoothLeScanner: onClientRegistered() - status=0 clientIf=5 mClientIf=0
D/ReactNativeBleManager: Disconnect from: 00:0E:0B:15:AC:98
D/BluetoothGatt: cancelOpen() - device: 00:0E:0B:15:AC:XX
D/BluetoothGatt: close()
D/BluetoothGatt: onClientConnectionState() - status=0 clientIf=11 device=00:0E:0B:15:AC:XX
D/BluetoothGatt: unregisterApp() - mClientIf=11
D/ReactNativeBleManager: Disconnect
D/ReactNativeBleManager: Peripheral event (BleManagerDisconnectPeripheral):00:0E:0B:15:AC:98
W/BluetoothGatt: Unhandled exception in callback
    java.lang.NullPointerException: Attempt to invoke virtual method 'void android.bluetooth.BluetoothGattCallback.onConnectionStateChange(android.bluetooth.BluetoothGatt, int, int)' on a null object reference
        at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:228)
        at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:70)
        at android.os.Binder.execTransact(Binder.java:573)
```

