### PR TITLE
Clear invalid data on adapter state change (Andorid)

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -359,9 +359,6 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			if (!peripherals.containsKey(address)) {
 				Peripheral peripheral = new Peripheral(device, reactContext);
 				peripherals.put(device.getAddress(), peripheral);
-			} else {
-				Peripheral peripheral = peripherals.get(address);
-				peripheral.updateDevice(device);
 			}
 		}
 		return peripherals.get(address);
@@ -375,7 +372,6 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				peripherals.put(device.getAddress(), peripheral);
 			} else {
 				Peripheral peripheral = peripherals.get(address);
-				peripheral.updateDevice(device);
 				peripheral.updateRssi(rssi);
 				peripheral.updateData(scanRecord);
 			}
@@ -391,7 +387,6 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				peripherals.put(device.getAddress(), peripheral);
 			} else {
 				Peripheral peripheral = peripherals.get(address);
-				peripheral.updateDevice(device);
 				peripheral.updateRssi(rssi);
 				peripheral.updateData(scanRecord);
 			}
@@ -435,12 +430,11 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				switch (state) {
 					case BluetoothAdapter.STATE_OFF:
 						stringState = "off";
-						synchronized (peripherals){
-							peripherals.clear();
-						}
+						clearPeripherals();
 						break;
 					case BluetoothAdapter.STATE_TURNING_OFF:
 						stringState = "turning_off";
+						disconnectPeripherals();
 						break;
 					case BluetoothAdapter.STATE_ON:
 						stringState = "on";
@@ -491,6 +485,26 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 
 		}
 	};
+
+	private void clearPeripherals() {
+		if (!peripherals.isEmpty()) {
+			synchronized (peripherals) {
+				peripherals.clear();
+			}
+		}
+	}
+
+	private void disconnectPeripherals() {
+		if (!peripherals.isEmpty()) {
+			synchronized (peripherals) {
+				for (Peripheral peripheral : peripherals.values()) {
+					if (peripheral.isConnected()) {
+						peripheral.disconnect(false);
+					}
+				}
+			}
+		}
+	}
 
 	@ReactMethod
 	public void getDiscoveredPeripherals(Callback callback) {

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -359,6 +359,9 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			if (!peripherals.containsKey(address)) {
 				Peripheral peripheral = new Peripheral(device, reactContext);
 				peripherals.put(device.getAddress(), peripheral);
+			} else {
+				Peripheral peripheral = peripherals.get(address);
+				peripheral.updateDevice(device);
 			}
 		}
 		return peripherals.get(address);
@@ -372,6 +375,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				peripherals.put(device.getAddress(), peripheral);
 			} else {
 				Peripheral peripheral = peripherals.get(address);
+				peripheral.updateDevice(device);
 				peripheral.updateRssi(rssi);
 				peripheral.updateData(scanRecord);
 			}
@@ -387,6 +391,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				peripherals.put(device.getAddress(), peripheral);
 			} else {
 				Peripheral peripheral = peripherals.get(address);
+				peripheral.updateDevice(device);
 				peripheral.updateRssi(rssi);
 				peripheral.updateData(scanRecord);
 			}

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -435,6 +435,9 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 				switch (state) {
 					case BluetoothAdapter.STATE_OFF:
 						stringState = "off";
+						synchronized (peripherals){
+							peripherals.clear();
+						}
 						break;
 					case BluetoothAdapter.STATE_TURNING_OFF:
 						stringState = "turning_off";

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -47,7 +47,7 @@ public class Peripheral extends BluetoothGattCallback {
 
 	private static final String CHARACTERISTIC_NOTIFICATION_CONFIG = "00002902-0000-1000-8000-00805f9b34fb";
 
-	private final BluetoothDevice device;
+	private BluetoothDevice device;
 	private ScanRecord advertisingData;
 	private byte[] advertisingDataBytes;
 	private int advertisingRSSI;
@@ -363,6 +363,12 @@ public class Peripheral extends BluetoothGattCallback {
 			requestMTUCallback = null;
 		}
 
+	}
+
+	public void updateDevice(BluetoothDevice bluetoothDevice) {
+		if (device != bluetoothDevice) {
+			device = bluetoothDevice;
+		}
 	}
 
 	public void updateRssi(int rssi) {

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -47,7 +47,7 @@ public class Peripheral extends BluetoothGattCallback {
 
 	private static final String CHARACTERISTIC_NOTIFICATION_CONFIG = "00002902-0000-1000-8000-00805f9b34fb";
 
-	private BluetoothDevice device;
+	private final BluetoothDevice device;
 	private ScanRecord advertisingData;
 	private byte[] advertisingDataBytes;
 	private int advertisingRSSI;
@@ -363,12 +363,6 @@ public class Peripheral extends BluetoothGattCallback {
 			requestMTUCallback = null;
 		}
 
-	}
-
-	public void updateDevice(BluetoothDevice bluetoothDevice) {
-		if (device != bluetoothDevice) {
-			device = bluetoothDevice;
-		}
 	}
 
 	public void updateRssi(int rssi) {


### PR DESCRIPTION
If a device was already connected when we turned off the Bluetooth adapter it caused an inconsistent state on Android: the Peripheral object's **connected flag stayed true**. And the following connect() calls would return a false positive.
Removing all items from the internal map when the state changed to "off" seems to be the simplest solution. 
Trying to do a graceful disconnect on "turning_off" is just an extra attempt to handle states according to the Android Api's documentation.

possibly related issue: #366 