### PR TITLE
Scanning on iOS does not clear peripherals cache in order to connect to same devices or other devices already previously scanned

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -310,6 +310,12 @@ RCT_EXPORT_METHOD(start:(NSDictionary *)options callback:(nonnull RCTResponseSen
 RCT_EXPORT_METHOD(scan:(NSArray *)serviceUUIDStrings timeoutSeconds:(nonnull NSNumber *)timeoutSeconds allowDuplicates:(BOOL)allowDuplicates options:(nonnull NSDictionary*)scanningOptions callback:(nonnull RCTResponseSenderBlock)callback)
 {
     NSLog(@"scan with timeout %@", timeoutSeconds);
+    
+    // Clear the peripherals before scanning again, otherwise cannot connect again after disconnection
+    @synchronized(peripherals) {
+        [peripherals removeAllObjects];
+    }
+    
     NSArray * services = [RCTConvert NSArray:serviceUUIDStrings];
     NSMutableArray *serviceUUIDs = [NSMutableArray new];
     NSDictionary *options = nil;


### PR DESCRIPTION
### Version

Tell us which versions you are using:

- react-native-ble-manager v6.62
- react-native v0.59 SDK 32
- iOS/Android iOS v.12

### Expected behaviour
When scanning for devices it shows up correctly.  Calling disconnect and rescan the devices again.  And then attempt to try to connect any new devices or the same device will NOT allow you to connect.

### Actual behaviour
Should clear the peripherals cache before scanning again. 

### Steps to reproduce

1.  Scan -> Connect
2. Disconnect from that Device
3. Rescan again, cannot connect again

