### PR TITLE
[Android] Change compile to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ repositories {
 
 
 dependencies {
-	compile 'com.facebook.react:react-native:[0.30.0,)'
+	implementation 'com.facebook.react:react-native:[0.30.0,)'
 }


### PR DESCRIPTION
Configutarion compile is deprecated since gradle 3.0. We need to use implementation or api instead. Here, implementation is appropriated because we don't need any transitivity. Almost every react-native native module library have replaced compile to implementation and now this great library also need to replace.