### PR TITLE
ble support is optional

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,5 +3,5 @@
 	<uses-permission android:name="android.permission.BLUETOOTH" />
 	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
+	<uses-feature android:name="android.hardware.bluetooth_le" android:required="false"/>
 </manifest>


### PR DESCRIPTION
App does not require ble to be supported, hence app should be allowed to be installed through play store