### PR TITLE
Updated peripheral list to not clear connecting/connected peripherals

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -316,9 +316,9 @@ RCT_EXPORT_METHOD(scan:(NSArray *)serviceUUIDStrings timeoutSeconds:(nonnull NSN
     // onDisconnect* callback).
     @synchronized(peripherals) {
       NSMutableArray *connectedPeripherals = [NSMutableArray array];
-      for(CBPeripheral *peripheral in peripherals){
-          if(([peripheral state] != CBPeripheralStateConnected) &&
-            ([peripheral state] != CBPeripheralStateConnecting)){
+      for (CBPeripheral *peripheral in peripherals) {
+          if (([peripheral state] != CBPeripheralStateConnected) &&
+              ([peripheral state] != CBPeripheralStateConnecting)) {
               [connectedPeripherals addObject:peripheral];
           }
       }

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -312,10 +312,21 @@ RCT_EXPORT_METHOD(scan:(NSArray *)serviceUUIDStrings timeoutSeconds:(nonnull NSN
     NSLog(@"scan with timeout %@", timeoutSeconds);
     
     // Clear the peripherals before scanning again, otherwise cannot connect again after disconnection
+    // Only clear peripherals that are not connected - otherwise connections fail silently (without any
+    // onDisconnect* callback).
     @synchronized(peripherals) {
-        [peripherals removeAllObjects];
+      NSMutableArray *connectedPeripherals = [NSMutableArray array];
+      for(CBPeripheral *peripheral in peripherals){
+          if(([peripheral state] != CBPeripheralStateConnected) &&
+            ([peripheral state] != CBPeripheralStateConnecting)){
+              [connectedPeripherals addObject:peripheral];
+          }
+      }
+      for (CBPeripheral *p in connectedPeripherals) {
+          [peripherals removeObject:p];
+      }
     }
-    
+
     NSArray * services = [RCTConvert NSArray:serviceUUIDStrings];
     NSMutableArray *serviceUUIDs = [NSMutableArray new];
     NSDictionary *options = nil;


### PR DESCRIPTION
Connecting to peripheral was working on the first scan, and sometimes on subsequent scans after the fix in 6.6.4. However, there were still issues connecting to peripherals with the following message:

 API MISUSE: Cancelling connection for unused peripheral <CBPeripheralXXXX>, Did you forget to keep a reference to it?

Keeping the connecting/connected peripherals across scans appears to resolve the issue.