### PR TITLE
Fixing unsupported state in android

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -391,7 +391,9 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 
 		BluetoothAdapter adapter = getBluetoothAdapter();
 		String state = "off";
-		if (adapter != null) {
+		if(!context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOH_LE)){
+			state = "unsupported"; 
+		} else if (adapter != null) {
 			switch (adapter.getState()) {
 				case BluetoothAdapter.STATE_ON:
 					state = "on";


### PR DESCRIPTION
With this change, the devices with does not support BLUETOOH_LE will return state as unsupported instead of "off", which happens currently