### PR TITLE
Fix multiple callback invocation

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -209,8 +209,10 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 		Peripheral peripheral = retrieveOrCreatePeripheral(peripheralUUID);
 		if (peripheral == null) {
 			callback.invoke("Invalid peripheral uuid");
+			return;
 		} else if (bondRequest != null) {
 			callback.invoke("Only allow one bond request at a time");
+			return;
 		} else if (peripheral.getDevice().createBond()) {
 			Log.d(LOG_TAG, "Request bond successful for: " + peripheralUUID);
 			bondRequest = new BondRequest(peripheralUUID, callback); // request bond success, waiting for boradcast


### PR DESCRIPTION
stop function execution after callback invocation, otherwise the code falls through to another callback and app crashes with error `Illegal callback invocation from native module. The callback type only permits a single invocation from native code`