### PR TITLE
Enable to pass a queue identifier on which the events will be dispatched

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ __Arguments__
 The parameter is optional the configuration keys are:
 - `showAlert` - `Boolean` - [iOS only] Show or hide the alert if the bluetooth is turned off during initialization
 - `restoreIdentifierKey` - `String` - [iOS only] Unique key to use for CoreBluetooth state restoration
+- `queueIdentifierKey` - `String` - [iOS only] Unique key to use for a queue identifier on which CoreBluetooth events will be dispatched
 - `forceLegacy` - `Boolean` - [Android only] Force to use the LegacyScanManager
 
 __Examples__

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -287,6 +287,13 @@ RCT_EXPORT_METHOD(start:(NSDictionary *)options callback:(nonnull RCTResponseSen
                         forKey:CBCentralManagerOptionShowPowerAlertKey];
     }
     
+    dispatch_queue_t queue;
+    if ([[options allKeys] containsObject:@"queueIdentifierKey"]) {
+        queue = dispatch_queue_create([[options valueForKey:@"queueIdentifierKey"] UTF8String], DISPATCH_QUEUE_SERIAL);
+    } else {
+        queue = dispatch_get_main_queue();
+    }
+    
     if ([[options allKeys] containsObject:@"restoreIdentifierKey"]) {
         
         [initOptions setObject:[options valueForKey:@"restoreIdentifierKey"]
@@ -296,11 +303,11 @@ RCT_EXPORT_METHOD(start:(NSDictionary *)options callback:(nonnull RCTResponseSen
             manager = _sharedManager;
             manager.delegate = self;
         } else {
-            manager = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue() options:initOptions];
+            manager = [[CBCentralManager alloc] initWithDelegate:self queue:queue options:initOptions];
             _sharedManager = manager;
         }
     } else {
-        manager = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue() options:initOptions];
+        manager = [[CBCentralManager alloc] initWithDelegate:self queue:queue options:initOptions];
         _sharedManager = manager;
     }
     


### PR DESCRIPTION
Previously, the main queue was passed to the initializer or `CBCentralManager`. It means the BLE events happened always in the main thread and were handled there. It had risks to block the UI.

With this fix, we can use a background thread by passing a queue identifier on which the events will be dispatched as follows:

```
BleManager.start({showAlert: false, queueIdentifierKey: 'com.shu223.example.queue.centralmanager'})
``` 