### PR TITLE
[TS] Add queueIdentifierKey to start()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-native-ble-manager' {
 	export interface StartOptions {
 		showAlert?: boolean
 		restoreIdentifierKey?: string
+		queueIdentifierKey?: string
 		forceLegacy?: boolean
 	}
 


### PR DESCRIPTION
As documented at https://github.com/innoveit/react-native-ble-manager#startoptions