### PR TITLE
Add synchronized to Android getDiscoveredPeripherals to fix ConcurrentModificationException

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -523,11 +523,12 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	public void getDiscoveredPeripherals(Callback callback) {
 		Log.d(LOG_TAG, "Get discovered peripherals");
 		WritableArray map = Arguments.createArray();
-		Map<String, Peripheral> peripheralsCopy = new LinkedHashMap<>(peripherals);
-		for (Map.Entry<String, Peripheral> entry : peripheralsCopy.entrySet()) {
-			Peripheral peripheral = entry.getValue();
-			WritableMap jsonBundle = peripheral.asWritableMap();
-			map.pushMap(jsonBundle);
+		synchronized (peripherals) {
+			for (Map.Entry<String, Peripheral> entry : peripherals.entrySet()) {
+				Peripheral peripheral = entry.getValue();
+				WritableMap jsonBundle = peripheral.asWritableMap();
+				map.pushMap(jsonBundle);
+			}
 		}
 		callback.invoke(null, map);
 	}


### PR DESCRIPTION
A copy of peripherals map was added to address this same exception, in a previous PR, but exception can still occur

Exception occurs if copy is being made of `peripherals` while `scan` is modifying `peripherals`

This PR adds a synchronized block in getDiscoveredPeripherals, following the convention in the rest of the code, and removes the copy