### PR TITLE
Fix NSInvalidArgumentException on iOS when parsing advertisement data for some devices

### DIFF
--- a/ios/NSData+Conversion.m
+++ b/ios/NSData+Conversion.m
@@ -27,7 +27,7 @@
     const unsigned char *dataBuffer = (const unsigned char *)[self bytes];
     
     if (!dataBuffer)
-        return NULL;
+        return [NSMutableArray new];
     
     NSUInteger          dataLength  = [self length];
     NSMutableArray     *array  = [NSMutableArray arrayWithCapacity:dataLength];


### PR DESCRIPTION
For some devices on iOS, when advertisement data is parsed with `serializableAdvertisementData`, the service data (value for `CBAdvertisementDataServiceDataKey`) might be `NULL`, which causes `(NSArray *)toArray` to return `NULL` and it raises `NSInvalidArgumentException` exception when we try to put this `NULL` as a value to `NSPlaceholderDictionary`.

To fix it I return empty array instead of `NULL` in from `(NSArray *)toArray` function.

It might fix the following issue:
https://github.com/innoveit/react-native-ble-manager/issues/542