### PR TITLE
Android gatt close fix

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -261,6 +261,12 @@ public class Peripheral extends BluetoothGattCallback {
 
 		this.gatt = gatta;
 
+		if (status != BluetoothGatt.GATT_SUCCESS) {
+		    // TODO: cancel the service discovery runnable
+		    gatt.close();
+
+		} else // if ...
+
 		if (newState == BluetoothProfile.STATE_CONNECTED) {
 
 			connected = true;

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -489,14 +489,14 @@ RCT_EXPORT_METHOD(write:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUI
     NSData *dataMessage = [NSData dataWithBytesNoCopy:bytes length:c freeWhenDone:YES];
     
     if (context) {
-        // RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[message count], message);
+        RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[message count], message);
         CBPeripheral *peripheral = [context peripheral];
         CBCharacteristic *characteristic = [context characteristic];
         
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
         [writeCallbacks setObject:callback forKey:key];
         
-        // RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[dataMessage length], [dataMessage hexadecimalString]);
+        RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[dataMessage length], [dataMessage hexadecimalString]);
         if ([dataMessage length] > maxByteSize){
             int dataLength = (int)dataMessage.length;
             int count = 0;

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -489,14 +489,14 @@ RCT_EXPORT_METHOD(write:(NSString *)deviceUUID serviceUUID:(NSString*)serviceUUI
     NSData *dataMessage = [NSData dataWithBytesNoCopy:bytes length:c freeWhenDone:YES];
     
     if (context) {
-        RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[message count], message);
+        // RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[message count], message);
         CBPeripheral *peripheral = [context peripheral];
         CBCharacteristic *characteristic = [context characteristic];
         
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
         [writeCallbacks setObject:callback forKey:key];
         
-        RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[dataMessage length], [dataMessage hexadecimalString]);
+        // RCTLogInfo(@"Message to write(%lu): %@ ", (unsigned long)[dataMessage length], [dataMessage hexadecimalString]);
         if ([dataMessage length] > maxByteSize){
             int dataLength = (int)dataMessage.length;
             int count = 0;


### PR DESCRIPTION
This is a fix to prevent fast reconnection attempts to eat up all available BLE identifiers.