### PR TITLE
Add scanOption check

### DIFF
--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -38,14 +38,20 @@ public class LollipopScanManager extends ScanManager {
         ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();
         List<ScanFilter> filters = new ArrayList<>();
         
-        scanSettingsBuilder.setScanMode(options.getInt("scanMode"));
+        if (options.hasKey("scanMode")) {
+            scanSettingsBuilder.setScanMode(options.getInt("scanMode"));
+        }
         
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            scanSettingsBuilder.setNumOfMatches(options.getInt("numberOfMatches"));
-            scanSettingsBuilder.setMatchMode(options.getInt("matchMode"));
+            if (options.hasKey("numberOfMatches")) {
+                scanSettingsBuilder.setNumOfMatches(options.getInt("numberOfMatches"));
+            }
+            if (options.hasKey("matchMode")) {
+                scanSettingsBuilder.setMatchMode(options.getInt("matchMode"));
+            }
         }
 
-        if (!options.isNull("reportDelay")) {
+        if (options.hasKey("reportDelay")) {
             scanSettingsBuilder.setReportDelay(options.getInt("reportDelay"));
         }
         


### PR DESCRIPTION
with using 7.1.0. If you did not send the ScanOption, you would get an error below

![截屏2020-06-06 13 07 43](https://user-images.githubusercontent.com/7650400/83935687-bcd39e00-a7f6-11ea-905e-c11b4c03c6f3.png)

Just as the type definition of scan method

https://github.com/innoveit/react-native-ble-manager/blob/08aa0475349bc76e0f0c9f86232c24565e3c5094/index.d.ts#L34

the ScanOption in method scan is an option parameter, so we should check the option before using it




