### PR TITLE
discoverServices removed from onConnectionStateChange

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -277,17 +277,6 @@ public class Peripheral extends BluetoothGattCallback {
 		if (newState == BluetoothProfile.STATE_CONNECTED) {
 			connected = true;
 
-			new Handler(Looper.getMainLooper()).post(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						gatt.discoverServices();
-					} catch (NullPointerException e) {
-						Log.d(BleManager.LOG_TAG, "onConnectionStateChange connected but gatt of Run method was null");
-					}
-				}
-			});
-
 			sendConnectionEvent(device, "BleManagerConnectPeripheral", status);
 
 			if (connectCallback != null) {


### PR DESCRIPTION
Trying to change the MTU directly after connection does not work because the device is performing this discoverServices. I think that is not useful because acording to the documentation the developer must do it manually from the react native code before making any read or write or whatever. I think that this discoverServices only makes fail some requests after the connected handler or promise.