### PR TITLE
add discover characteristics in included service (ios)

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -876,8 +876,13 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     [retrieveServicesLatches setObject:servicesForPeriperal forKey:[peripheral uuidAsString]];
     for (CBService *service in peripheral.services) {
         NSLog(@"Service %@ %@", service.UUID, service.description);
-        [peripheral discoverCharacteristics:nil forService:service]; // discover all is slow
+        [peripheral discoverIncludedServices:nil forService:service]; // discover included services
+        [peripheral discoverCharacteristics:nil forService:service]; // discover characteristics for service
     }
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverIncludedServicesForService:(CBService *)service error:(NSError *)error {
+    [peripheral discoverCharacteristics:nil forService:service]; // discover characteristics for included service
 }
 
 - (void)peripheral:(CBPeripheral *)peripheral didDiscoverCharacteristicsForService:(CBService *)service error:(NSError *)error {


### PR DESCRIPTION
for some peripheral there is a possibility that characteristics are part of a service where the service it self is actually an included service.

discovering this type of characteristic requires implementation of [discoverIncludedServices:forService:
](https://developer.apple.com/documentation/corebluetooth/cbperipheral/1519014-discoverincludedservices?language=objc)