### PR TITLE
backport NSInvalidArgumentException fix to v6

### DIFF
--- a/ios/NSData+Conversion.m
+++ b/ios/NSData+Conversion.m
@@ -27,7 +27,7 @@
     const unsigned char *dataBuffer = (const unsigned char *)[self bytes];
     
     if (!dataBuffer)
-        return NULL;
+        return [NSMutableArray new];
     
     NSUInteger          dataLength  = [self length];
     NSMutableArray     *array  = [NSMutableArray arrayWithCapacity:dataLength];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ble-manager",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "A BLE module for react native.",
   "main": "BleManager",
   "types": "./index.d.ts",


### PR DESCRIPTION
Backports https://github.com/innoveit/react-native-ble-manager/pull/624 to v6.

@marcosinigaglia Thanks for all your work on the library! Would it be possible to release a v6.7.2 patch from this branch? All the PR does is backport the fix to the v6 version of the lib