### PR TITLE
Fix for RN event warnings

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -722,4 +722,14 @@ class BleManager extends ReactContextBaseJavaModule {
         return peripheral;
     }
 
+   @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+     public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ble-manager",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "description": "A BLE module for react native.",
   "main": "BleManager",
   "types": "./index.d.ts",


### PR DESCRIPTION
This will suppress the warnings shown by React v0.65.

 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method. 

