### PR TITLE
feat: Restructure scan(), include manufactureData filtering

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -243,7 +243,7 @@ class BleManager {
     });
   }
 
-  scan(serviceUUIDs, seconds, allowDuplicates, scanningOptions = {}) {
+  scan(serviceUUIDs, manufacturerInfos, seconds, allowDuplicates, scanningOptions = {}) {
     return new Promise((fulfill, reject) => {
       if (allowDuplicates == null) {
         allowDuplicates = false;
@@ -271,6 +271,7 @@ class BleManager {
 
       bleManager.scan(
         serviceUUIDs,
+        manufacturerInfos,
         seconds,
         allowDuplicates,
         scanningOptions,

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -177,7 +177,7 @@ class BleManager extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void scan(ReadableArray serviceUUIDs, final int scanSeconds, boolean allowDuplicates, ReadableMap options,
+    public void scan(ReadableArray serviceUUIDs, ReadableArray manufacturerInfos, final int scanSeconds, boolean allowDuplicates, ReadableMap options,
                      Callback callback) {
         Log.d(LOG_TAG, "scan");
         if (getBluetoothAdapter() == null) {
@@ -200,7 +200,8 @@ class BleManager extends ReactContextBaseJavaModule {
         }
 
         if (scanManager != null)
-            scanManager.scan(serviceUUIDs, scanSeconds, options, callback);
+            Log.d(LOG_TAG, "Scanning, filtered by UUID & ManufacturerData");
+            scanManager.scan(serviceUUIDs, manufacturerInfos, scanSeconds, options, callback);
     }
 
     @ReactMethod
@@ -699,7 +700,6 @@ class BleManager extends ReactContextBaseJavaModule {
             value.pushInt((bytes[i] & 0xFF));
         return value;
     }
-
 
     private Peripheral retrieveOrCreatePeripheral(String peripheralUUID) {
         Peripheral peripheral = peripherals.get(peripheralUUID);

--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -52,7 +52,7 @@ public class LegacyScanManager extends ScanManager {
 			};
 
 	@Override
-	public void scan(ReadableArray serviceUUIDs, final int scanSeconds, ReadableMap options, Callback callback) {
+	public void scan(ReadableArray serviceUUIDs, ReadableArray manufacturerInfos, final int scanSeconds, ReadableMap options, Callback callback) {
 		if (serviceUUIDs.size() > 0) {
 			Log.d(bleManager.LOG_TAG, "Filter is not working in pre-lollipop devices");
 		}

--- a/android/src/main/java/it/innove/ScanManager.java
+++ b/android/src/main/java/it/innove/ScanManager.java
@@ -35,5 +35,7 @@ public abstract class ScanManager {
 
 	public abstract void stopScan(Callback callback);
 
-	public abstract void scan(ReadableArray serviceUUIDs, final int scanSeconds, ReadableMap options, Callback callback);
+	//public abstract void scan(ReadableArray serviceUUIDs, final int scanSeconds, ReadableMap options, Callback callback);
+
+	public abstract void scan(ReadableArray serviceUUIDs, ReadableArray manufacturerInfos, final int scanSeconds, ReadableMap options, Callback callback);
 }


### PR DESCRIPTION
This allows using the manufacturerSpecificData to filter the scanning process.
One specific use-case is to detect overflow area advertisements from iOS ble in background.