### PR TITLE
fix: remove duplicate disconnect event trigger

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -322,7 +322,6 @@ public class Peripheral extends BluetoothGattCallback {
 				discoverServicesRunnable = null;
 			}
 
-			sendConnectionEvent(device, "BleManagerDisconnectPeripheral", status);
 			List<Callback> callbacks = Arrays.asList(writeCallback, retrieveServicesCallback, readRSSICallback,
 					readCallback, registerNotifyCallback, requestMTUCallback);
 			for (Callback currentCallback : callbacks) {


### PR DESCRIPTION
The "sendConnectionEvent()" method was duplicate when "disconnect()" method is trigger on Peripheral.java file.