### PR TITLE
Fix connect promise will never reject on error

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -315,8 +315,6 @@ public class Peripheral extends BluetoothGattCallback {
 
 		} else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
 
-			this.disconnect(true);
-
 			if (discoverServicesRunnable != null) {
 				mainHandler.removeCallbacks(discoverServicesRunnable);
 				discoverServicesRunnable = null;
@@ -342,6 +340,8 @@ public class Peripheral extends BluetoothGattCallback {
 			requestMTUCallback = null;
 			commandQueue.clear();
 			commandQueueBusy = false;
+
+			this.disconnect(true);
 		}
 
 	}


### PR DESCRIPTION
Issue:
On Android, the connect promise will be held on connection fail. It won't fulfil nor reject.

Recreate issue:

BleManager.connect(peripheral).then(function(){
  console.log("Connection success");
}).catch(function(error){
  console.log("Connection Fail, but this line will never run");
})

Cause:
in the onConnectionStateChange function under Peripheral.java, when the state changed to STATE_DISCONNECTED, it will immediate trigger disconnect. But disconnect function will remove the connection callback, which render the promise rejection on the next few line unusable.

Fix:
Move the disconnect function call after all the callback reset and queue clear.