### PR TITLE
Fix "peripheral not found" on retrieveServices while scanning [Android]

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -193,7 +193,7 @@ class BleManager extends ReactContextBaseJavaModule {
             for (Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator
                     .hasNext(); ) {
                 Map.Entry<String, Peripheral> entry = iterator.next();
-                if (!entry.getValue().isConnected()) {
+                if (!(entry.getValue().isConnected() || entry.getValue().isConnecting())) {
                     iterator.remove();
                 }
             }

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -53,6 +53,7 @@ public class Peripheral extends BluetoothGattCallback {
 	protected byte[] advertisingDataBytes = new byte[0];
 	protected int advertisingRSSI;
 	private boolean connected = false;
+	private boolean connecting = false;
 	private ReactContext reactContext;
 
 	private BluetoothGatt gatt;
@@ -104,6 +105,7 @@ public class Peripheral extends BluetoothGattCallback {
 		if (!connected) {
 			BluetoothDevice device = getDevice();
 			this.connectCallback = callback;
+			this.connecting = true;
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 				Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
 				gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE);
@@ -252,6 +254,10 @@ public class Peripheral extends BluetoothGattCallback {
 		return connected;
 	}
 
+	public boolean isConnecting() {
+		return connecting;
+	}
+
 	public BluetoothDevice getDevice() {
 		return device;
 	}
@@ -288,6 +294,7 @@ public class Peripheral extends BluetoothGattCallback {
 		    newState = BluetoothProfile.STATE_DISCONNECTED;
 		}
 
+		connecting = false;
 		if (newState == BluetoothProfile.STATE_CONNECTED) {
 			connected = true;
 


### PR DESCRIPTION
Issue:
On Android, if we try to repeating scanning for BLE device and try to repeat connect to a device through MAC address at the same time, we will experience "Peripheral Not Found" on retrieveServices after device connected.

Recreate issue:
 
  var BleManagerModule = NativeModules.BleManager;
  var ble_emitter = new NativeEventEmitter(BleManagerModule);

  const onConnect = function ({ peripheral }) {
    BleManager.retrieveServices(peripheral).then(function () {
      console.log("Connection Successful");
      //Further Action
    }).catch(function (error) {
      console.log("Retrieve Servcies Error:", error);
      //Peripheral Not Found
    });
  }

  const onDisconnect = function ({ peripheral }) {
    BleManager.connect(peripheral).catch(function () {
      console.log("Reconnection Fail ", peripheral);
    });
  }

  const onScanStop = function () {
    BleManager.scan([], 5, true);
  }

  useEffect(function () {
    BleManager.start().then(function () {
      ble_emitter.addListener('BleManagerStopScan', onScanStop);
      ble_emitter.addListener('BleManagerConnectPeripheral', onConnect);
      ble_emitter.addListener('BleManagerDisconnectPeripheral', onDisconnect);
      BleManager.scan([], 5, true);
      BleManager.connect("XX:XX:XX:XX:XX:XX").catch(function () {
        console.log("Connection Fail");
      });
      BleManager.connect("XX:XX:XX:XX:XX:XX").catch(function () {
        console.log("Connection Fail");
      });
    });


The above code will restart a scan when the scan ends, and it will try to re-connect a device if the connection fails.
By turning the device on and off, sometime the connect will success normally and sometime connection success but  "Peripheral Not Found" on retrieveServices.


Cause:
When a scan start, BleManager will remove all the peripheral from the list which are not connected. But there is a racing condition which the peripheral is connecting but the start of scan has already removed the peripheral since it is not connected. 
Later when the peripheral has completed the connection and trigger the "BleManagerConnectPeripheral" event, the further command like "retrieveServices" will start to look for the peripheral on the list. This will render the "Peripheral Not Found" Error.

Fix:
Adding a "connecting" flag to the peripheral, which will be called when the connect function is called on the peripheral and the flag will be turn off when the connection state changes regardless connection successful or fail. 
On the BleManager scan function, originally it will not remove peripheral when it is connected. Now it also will not remove the peripheral which is connecting.
