### PR TITLE
Add NSError domain and NSError code to BleManagerDisconnectPeripheral event

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,8 @@ A peripheral was disconnected.
 
 - `peripheral` - `String` - the id of the peripheral
 - `status` - `Number` - [Android only] disconnect [`reasons`](<https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback.html#onConnectionStateChange(android.bluetooth.BluetoothGatt,%20int,%20int)>)
+- `domain` - `String` - [iOS only] disconnect error domain
+- `code` - `Number` - [iOS only] disconnect error code (<https://developer.apple.com/documentation/corebluetooth/cberror/code>)
 
 ### BleManagerPeripheralDidBond
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -861,7 +861,7 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     
     if (hasListeners) {
 			if (error) {
-				[self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString], @"status": error.code}];
+				[self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString], @"domain": [error domain], @"code": @(error.code)}];
 			} else {
 				[self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString]}];
 			}

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -860,7 +860,11 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     }
     
     if (hasListeners) {
-        [self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString]}];
+			if (error) {
+				[self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString], @"status": error.code}];
+			} else {
+				[self sendEventWithName:@"BleManagerDisconnectPeripheral" body:@{@"peripheral": [peripheral uuidAsString]}];
+			}
     }
 }
 


### PR DESCRIPTION
### Description
Implements #798. Solved by just adding a `domain` and a `code` field to the `BleManagerDisconnetPeripheral` event. Similar to how the solution is with the android `status`.

### Verification
- [x] Tested by triggering a few errors with the peripherals I have available
- [x] Tested both routes manually