### PR TITLE
Add BleManagerDidUpdateNotificationStateFor

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,3 +804,15 @@ _For more on performing long-term bluetooth actions in the background:_
 [iOS Bluetooth State Preservation and Restoration](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10)
 
 [iOS Relaunch Conditions](https://developer.apple.com/library/archive/qa/qa1962/_index.html)
+
+### BleManagerDidUpdateNotificationStateFor [iOS only]
+
+The peripheral received a request to start or stop providing notifications for a specified characteristic's value.
+
+**Arguments**
+
+- `peripheral` - `String` - the id of the peripheral
+- `characteristic` - `String` - the UUID of the characteristic
+- `isNotifying` - `Boolean` - Is the characteristic notifying or not
+- `domain` - `String` - [iOS only] error domain
+- `code` - `Number` - [iOS only] error code

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -110,11 +110,9 @@ bool hasListeners;
         if (characteristic == nil){
             return;
         }
-				if (hasListeners) {
-						[self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral":
-								peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying":
-								@(false), @"domain": [error domain], @"code": @(error.code)}];
-				}
+        if (hasListeners) {
+            [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(false), @"domain": [error domain], @"code": @(error.code)}];
+        }
     }
     
     NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
@@ -143,11 +141,9 @@ bool hasListeners;
             [stopNotificationCallbacks removeObjectForKey:key];
         }
     }
-		if (hasListeners) {
-				[self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral":
-						peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying":
-						@(characteristic.isNotifying)}];
-		}
+    if (hasListeners) {
+        [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(characteristic.isNotifying)}];
+    }
 }
 
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -76,7 +76,7 @@ bool hasListeners;
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"BleManagerDidUpdateValueForCharacteristic", @"BleManagerStopScan", @"BleManagerDiscoverPeripheral", @"BleManagerConnectPeripheral", @"BleManagerDisconnectPeripheral", @"BleManagerDidUpdateState", @"BleManagerCentralManagerWillRestoreState"];
+    return @[@"BleManagerDidUpdateValueForCharacteristic", @"BleManagerStopScan", @"BleManagerDiscoverPeripheral", @"BleManagerConnectPeripheral", @"BleManagerDisconnectPeripheral", @"BleManagerDidUpdateState", @"BleManagerCentralManagerWillRestoreState", @"BleManagerDidUpdateNotificationStateFor"];
 }
 
 
@@ -110,6 +110,11 @@ bool hasListeners;
         if (characteristic == nil){
             return;
         }
+				if (hasListeners) {
+						[self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral":
+								peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying":
+								@(false), @"domain": [error domain], @"code": @(error.code)}];
+				}
     }
     
     NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
@@ -138,6 +143,11 @@ bool hasListeners;
             [stopNotificationCallbacks removeObjectForKey:key];
         }
     }
+		if (hasListeners) {
+				[self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral":
+						peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying":
+						@(characteristic.isNotifying)}];
+		}
 }
 
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -111,7 +111,7 @@ bool hasListeners;
             return;
         }
         if (hasListeners) {
-            [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(false), @"domain": [error domain], @"code": @(error.code)}];
+            [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(false), @"domain": [error domain], @"code": @(error.code)}];
         }
     }
     
@@ -142,7 +142,7 @@ bool hasListeners;
         }
     }
     if (hasListeners) {
-        [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" @body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(characteristic.isNotifying)}];
+        [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(characteristic.isNotifying)}];
     }
 }
 


### PR DESCRIPTION
### Rationale
Adding a new event listener to listen for `didUpdateNotificationStateFor` events. https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/1518768-peripheral

My use case is to be able to detect for failed bonds by listening for this event https://developer.apple.com/documentation/corebluetooth/cbatterror/code/insufficientencryption

I suspect there are a lot of other use cases for this too, so prolly nice to include.

### Verification
I have run my tests on a iPhone 8. It is tested manually with a few different peripherals I have available. 