### PR TITLE
android: Disconnect connected peripherals on react native reload

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -732,4 +732,19 @@ class BleManager extends ReactContextBaseJavaModule {
       // Keep: Required for RN built in Event Emitter Calls.
     }
 
+    @Override
+    public void onCatalystInstanceDestroy() {
+        try {
+            // Disconnect all known peripherals, otherwise android system will think we are still connected
+            // while we have lost the gatt instance
+            disconnectPeripherals();
+        }catch(Exception e) {
+            Log.d(LOG_TAG, "Could not disconnect peripherals", e);
+        }
+
+        if (scanManager != null) {
+            // Stop scan in case one was started to stop events from being emitted after destroy
+            scanManager.stopScan(args -> {});
+        }
+    }
 }


### PR DESCRIPTION
Previously the gatt instances returned by android would be lost, which
would have the android system keep the connection open until the app
was restarted

Also stop scanning to avoid sending events to a disposed react native
bridge

This fixed #795 for me after hot reloads during development.