### PR TITLE
Fixed issue with non-legacy crash

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -410,6 +410,10 @@ class BleManager {
       });
     });
   }
+
+  setName(name) {
+    bleManager.setName(name);
+  }
 }
 
 module.exports = new BleManager();

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -481,6 +481,12 @@ class BleManager extends ReactContextBaseJavaModule {
         sendEvent("BleManagerDidUpdateState", map);
     }
 
+    @ReactMethod
+    public void setName(String name) {
+        BluetoothAdapter adapter = getBluetoothAdapter();
+        adapter.setName(name);
+    }
+
     private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {

--- a/android/src/main/java/it/innove/LollipopPeripheral.java
+++ b/android/src/main/java/it/innove/LollipopPeripheral.java
@@ -82,9 +82,9 @@ public class LollipopPeripheral extends Peripheral {
 		return map;
 	}
 
-	public void updateData(ScanRecord scanRecord) {
-		advertisingData = scanRecord;
-		advertisingDataBytes = scanRecord.getBytes();
+	public void updateData(ScanResult result) {
+		advertisingData = result.getScanRecord();
+		advertisingDataBytes = advertisingData.getBytes();
 	}
 
 

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -123,7 +123,7 @@ public class LollipopScanManager extends ScanManager {
                     if (peripheral == null) {
                         peripheral = new LollipopPeripheral(bleManager.getReactContext(), result);
                     } else {
-                        peripheral.updateData(result.getScanRecord());
+                        peripheral.updateData(result);
                         peripheral.updateRssi(result.getRssi());
                     }
                     bleManager.savePeripheral(peripheral);

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,9 @@ declare module "react-native-ble-manager" {
   export function getBondedPeripherals(): Promise<Peripheral[]>;
   export function removePeripheral(peripheralID: string): Promise<void>;
 
-  
+  // [Android only]
+  export function setName(name: string): void;
+
   export interface Service {
     uuid: string;
   }
@@ -148,7 +150,7 @@ declare module "react-native-ble-manager" {
     characteristic: string;
     service: string;
     descriptors?: Descriptor[];
-    
+
   }
 
   export interface PeripheralInfo extends Peripheral {


### PR DESCRIPTION
Changes:

- Fixes #860 
- Exposed a new method to setName of BluetoothAdapter (https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#setName(java.lang.String)). This was required because a vendor insisted to only bond device if the bluetooth client name had a certain string.