### PR TITLE
Multiple Fixes

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -410,6 +410,10 @@ class BleManager {
       });
     });
   }
+
+  setName(name) {
+    bleManager.setName(name);
+  }
 }
 
 module.exports = new BleManager();

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -481,6 +481,12 @@ class BleManager extends ReactContextBaseJavaModule {
         sendEvent("BleManagerDidUpdateState", map);
     }
 
+    @ReactMethod
+    public void setName(String name) {
+        BluetoothAdapter adapter = getBluetoothAdapter();
+        adapter.setName(name);
+    }
+
     private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {

--- a/android/src/main/java/it/innove/LollipopPeripheral.java
+++ b/android/src/main/java/it/innove/LollipopPeripheral.java
@@ -82,9 +82,9 @@ public class LollipopPeripheral extends Peripheral {
 		return map;
 	}
 
-	public void updateData(ScanRecord scanRecord) {
-		advertisingData = scanRecord;
-		advertisingDataBytes = scanRecord.getBytes();
+	public void updateData(ScanResult result) {
+		advertisingData = result.getScanRecord();
+		advertisingDataBytes = advertisingData.getBytes();
 	}
 
 

--- a/android/src/main/java/it/innove/LollipopPeripheral.java
+++ b/android/src/main/java/it/innove/LollipopPeripheral.java
@@ -41,7 +41,9 @@ public class LollipopPeripheral extends Peripheral {
 
 			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
 				// We can check if peripheral is connectable using the scanresult
-				advertising.putBoolean("isConnectable", scanResult.isConnectable());
+				if (this.scanResult != null) {
+					advertising.putBoolean("isConnectable", scanResult.isConnectable());
+				}
 			} else{
 				// We can't check if peripheral is connectable
 				advertising.putBoolean("isConnectable", true);

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -123,7 +123,7 @@ public class LollipopScanManager extends ScanManager {
                     if (peripheral == null) {
                         peripheral = new LollipopPeripheral(bleManager.getReactContext(), result);
                     } else {
-                        peripheral.updateData(result.getScanRecord());
+                        peripheral.updateData(result);
                         peripheral.updateRssi(result.getRssi());
                     }
                     bleManager.savePeripheral(peripheral);

--- a/android/src/main/java/it/innove/NotifyBufferContainer.java
+++ b/android/src/main/java/it/innove/NotifyBufferContainer.java
@@ -3,26 +3,33 @@ package it.innove;
 import java.nio.ByteBuffer;
 
 public class NotifyBufferContainer {
-    public final String key;
-    public final Integer maxCount;
+    public final Integer maxBufferSize;
     private Integer bufferCount;
     public ByteBuffer items;
 
-    public NotifyBufferContainer(String key, Integer count) {
-
-        this.key = key;
-        this.maxCount = count;
+    public NotifyBufferContainer(Integer size) {
+        this.maxBufferSize = size;
         this.resetBuffer();
     }
     public void resetBuffer(){
-        this.bufferCount =0;
-        this.items = ByteBuffer.wrap(new byte[this.maxCount * 20]);
+        this.bufferCount = 0;
+        this.items = ByteBuffer.allocate(this.maxBufferSize);
     }
     public void put(byte[] value){
-        this.bufferCount +=1;
+        this.bufferCount += value.length;
+        if (this.items.remaining() < value.length) {
+            return;
+        }
         this.items.put(value);
     }
-    public Integer size(){
+    public boolean isBufferFull(){
+        return this.bufferCount >= this.maxBufferSize;
+    }
+    public Integer size() {
         return this.bufferCount;
+    }
+    @Override 
+    protected void finalize() throws Throwable {
+        this.items = ByteBuffer.allocate(0);
     }
 }

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -378,10 +378,10 @@ public class Peripheral extends BluetoothGattCallback {
 			byte[] dataValue = characteristic.getValue();
 			if (buffer != null) {
 				buffer.put(dataValue);
-				// Log.d(BleManager.LOG_TAG, "onCharacteristicChanged-buffering: " +
-				// buffer.size() + " from peripheral: " + device.getAddress());
+				Log.d(BleManager.LOG_TAG, "onCharacteristicChanged-buffering: " +
+				buffer.size() + " from peripheral: " + device.getAddress());
 
-				if (buffer.size().equals(buffer.maxCount)) {
+				if (buffer.isBufferFull()) {
 					Log.d(BleManager.LOG_TAG, "onCharacteristicChanged sending buffered data " + buffer.size());
 
 					// send'm and reset
@@ -581,11 +581,21 @@ public class Peripheral extends BluetoothGattCallback {
 
 	public void registerNotify(UUID serviceUUID, UUID characteristicUUID, Integer buffer, Callback callback) {
 		Log.d(BleManager.LOG_TAG, "registerNotify");
+		if (buffer > 1) {
+			Log.d(BleManager.LOG_TAG, "registerNotify using buffer");
+			String bufferKey = this.bufferedCharacteristicsKey(serviceUUID.toString(), characteristicUUID.toString());
+			this.bufferedCharacteristics.put(bufferKey, new NotifyBufferContainer(buffer));
+		}
 		this.setNotify(serviceUUID, characteristicUUID, true, callback);
 	}
 
 	public void removeNotify(UUID serviceUUID, UUID characteristicUUID, Callback callback) {
 		Log.d(BleManager.LOG_TAG, "removeNotify");
+		String bufferKey = this.bufferedCharacteristicsKey(serviceUUID.toString(), characteristicUUID.toString());
+		if (this.bufferedCharacteristics.containsKey(bufferKey)) {
+			NotifyBufferContainer buffer = this.bufferedCharacteristics.get(bufferKey);	
+			this.bufferedCharacteristics.remove(bufferKey);
+		}
 		this.setNotify(serviceUUID, characteristicUUID, false, callback);
 	}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,9 @@ declare module "react-native-ble-manager" {
   export function getBondedPeripherals(): Promise<Peripheral[]>;
   export function removePeripheral(peripheralID: string): Promise<void>;
 
-  
+  // [Android only]
+  export function setName(name: string): void;
+
   export interface Service {
     uuid: string;
   }
@@ -148,7 +150,7 @@ declare module "react-native-ble-manager" {
     characteristic: string;
     service: string;
     descriptors?: Descriptor[];
-    
+
   }
 
   export interface PeripheralInfo extends Peripheral {


### PR DESCRIPTION
Changes:

- Fixes #860 

- Re-implemented Buffering (Works a bit differently than previous implementation)
Current implementation counts the number of bytes received and buffers until we get more that that many bytes. Previous implementation counted number of characteristics notifications received.

- Exposed a new method to setName of BluetoothAdapter (https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#setName(java.lang.String)). This was required because a vendor insisted to only bond device if the bluetooth client name had a certain string.