### PR TITLE
added setLegacy option to scan method

### DIFF
--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -39,8 +39,8 @@ public class LollipopScanManager extends ScanManager {
         ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();
         List<ScanFilter> filters = new ArrayList<>();
 
-        if (options.hasKey("setLegacy")) {
-            scanSettingsBuilder.setScanMode(options.getBoolean("setLegacy"));
+        if (options.hasKey("legacy")) {
+            scanSettingsBuilder.setLegacy(options.getBoolean("legacy"));
         }
         
         if (options.hasKey("scanMode")) {

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -38,6 +38,10 @@ public class LollipopScanManager extends ScanManager {
     public void scan(ReadableArray serviceUUIDs, final int scanSeconds, ReadableMap options,  Callback callback) {
         ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();
         List<ScanFilter> filters = new ArrayList<>();
+
+        if (options.hasKey("setLegacy")) {
+            scanSettingsBuilder.setScanMode(options.getBoolean("setLegacy"));
+        }
         
         if (options.hasKey("scanMode")) {
             scanSettingsBuilder.setScanMode(options.getInt("scanMode"));

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ declare module "react-native-ble-manager" {
     scanMode?: number;
     reportDelay?: number;
     phy?: number;
+    setLegacy?: boolean;
   }
 
   export function scan(

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module "react-native-ble-manager" {
     scanMode?: number;
     reportDelay?: number;
     phy?: number;
-    setLegacy?: boolean;
+    legacy?: boolean;
   }
 
   export function scan(


### PR DESCRIPTION
Hello, 

there is an option in the android ScanSettingsBuilder to use newer features introduced in bluetooth 5. The name of this option is [setLegacy](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)), and it allows for features such as BLE extended broadcasting. By default, the value is true, but having the option to set it to false would be a good feature to have. I have tested with a sample app, and it does pick up on BLE extended broadcasting.