### PR TITLE
Fix readRSSI locking up the commandQueue on android

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -492,6 +492,8 @@ public class Peripheral extends BluetoothGattCallback {
 
 			readRSSICallback = null;
 		}
+
+		completedCommand();
 	}
 
 	private String bufferedCharacteristicsKey(String serviceUUID, String characteristicUUID) {
@@ -745,7 +747,7 @@ public class Peripheral extends BluetoothGattCallback {
 			    if (isConnected()) {
 				readRSSICallback = callback;
 				if (! gatt.readRemoteRssi()) {
-				    readCallback = null;
+					readRSSICallback = null;
 				    sendBackrError(callback, "Read RSSI failed");
 				    completedCommand();
 				}


### PR DESCRIPTION
Previously the `onReadRemoteRssi` callback did not call `completedCommand`, which appears to be necessary to unlock the `commandQueue`.

Additionally the readRSSI previously nulled the `readCallback` which does not appear to be correct, as that callback belongs to a read operation. Instead, it should null its own callback field: `readRSSICallback`

This fixes #876 for me. It is worth noting that the example app does readRSSI after connecting to a device, so this issue might be fairly common.