### PR TITLE
Fix to avoid MessageQueue Invariant Violation

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -331,8 +331,11 @@ public class Peripheral extends BluetoothGattCallback {
 					readCallback, registerNotifyCallback, requestMTUCallback);
 			for (Callback currentCallback : callbacks) {
 				if (currentCallback != null) {
-					currentCallback.invoke("Device disconnected");
-				}
+					try {
+						currentCallback.invoke("Device disconnected");
+					} catch (Exception e) {
+						e.printStackTrace();
+					}				}
 			}
 			if (connectCallback != null) {
 				connectCallback.invoke("Connection error");


### PR DESCRIPTION
Prior to this patch, on abrupt disconnection while reading, there was an React Native MessageQueue exception