### PR TITLE
Updated README.md to include default maxByteSize of write function

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Returns a `Promise` object.
 - `serviceUUID` - `String` - the UUID of the service.
 - `characteristicUUID` - `String` - the UUID of the characteristic.
 - `data` - `Byte array` - the data to write.
-- `maxByteSize` - `Integer` - specify the max byte size before splitting message
+- `maxByteSize` - `Integer` - specify the max byte size before splitting message, defaults to 20 bytes if not specified
 
 **Data preparation**
 


### PR DESCRIPTION
To avoid that other people run into a similar problem in the past, I've updated the documentation to include the default maxByteSize of the write function.