### PR TITLE
Adds reason field to BleManagerStopScan event for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ The scanning for peripherals is ended.
 
 **Arguments**
 
-- `reason` - `Number` - [Android only] the reason for stopping the scan
+- `reason` - `Number` - [Android only] the reason for stopping the scan (<https://developer.android.com/reference/android/bluetooth/le/ScanCallback#constants_1>). Error code 10 is used for timeouts
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -691,8 +691,7 @@ The scanning for peripherals is ended.
 
 **Arguments**
 
-- `reason` - `Number` - [Android only] the reason for stopping the scan (<https://developer.android.com/reference/android/bluetooth/le/ScanCallback#constants_1>). Error code 10 is used for timeouts
-- `status` - `Number` - [iOS only] the reason for stopping the scan. Error code 10 is used for timeouts, 0 covers everything else.
+- `status` - `Number` - [iOS] the reason for stopping the scan. Error code 10 is used for timeouts, 0 covers everything else. [Android] the reason for stopping the scan (<https://developer.android.com/reference/android/bluetooth/le/ScanCallback#constants_1>). Error code 10 is used for timeouts
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ The scanning for peripherals is ended.
 **Arguments**
 
 - `reason` - `Number` - [Android only] the reason for stopping the scan (<https://developer.android.com/reference/android/bluetooth/le/ScanCallback#constants_1>). Error code 10 is used for timeouts
+- `status` - `Number` - [iOS only] the reason for stopping the scan. Error code 10 is used for timeouts, 0 covers everything else.
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -691,12 +691,12 @@ The scanning for peripherals is ended.
 
 **Arguments**
 
-- `none`
+- `reason` - `Number` - [Android only] the reason for stopping the scan
 
 **Examples**
 
 ```js
-bleManagerEmitter.addListener("BleManagerStopScan", () => {
+bleManagerEmitter.addListener("BleManagerStopScan", (args) => {
   // Scanning is stopped
 });
 ```

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -218,7 +218,7 @@ class BleManager extends ReactContextBaseJavaModule {
         if (scanManager != null) {
             scanManager.stopScan(callback);
             WritableMap map = Arguments.createMap();
-						map.putInt("reason", 0);
+						map.putInt("status", 0);
             sendEvent("BleManagerStopScan", map);
         }
     }

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -218,6 +218,7 @@ class BleManager extends ReactContextBaseJavaModule {
         if (scanManager != null) {
             scanManager.stopScan(callback);
             WritableMap map = Arguments.createMap();
+						map.putInt("reason", 0);
             sendEvent("BleManagerStopScan", map);
         }
     }

--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -80,7 +80,7 @@ public class LegacyScanManager extends ScanManager {
 									btAdapter.stopLeScan(mLeScanCallback);
 								}
 								WritableMap map = Arguments.createMap();
-								map.putInt("reason", 0);
+								map.putInt("status", 0);
 								bleManager.sendEvent("BleManagerStopScan", map);
 							}
 						}

--- a/android/src/main/java/it/innove/LegacyScanManager.java
+++ b/android/src/main/java/it/innove/LegacyScanManager.java
@@ -80,6 +80,7 @@ public class LegacyScanManager extends ScanManager {
 									btAdapter.stopLeScan(mLeScanCallback);
 								}
 								WritableMap map = Arguments.createMap();
+								map.putInt("reason", 0);
 								bleManager.sendEvent("BleManagerStopScan", map);
 							}
 						}

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -101,7 +101,7 @@ public class LollipopScanManager extends ScanManager {
                                     btAdapter.getBluetoothLeScanner().stopScan(mScanCallback);
                                 }
                                 WritableMap map = Arguments.createMap();
-																map.putInt("reason", 10);
+																map.putInt("status", 10);
                                 bleManager.sendEvent("BleManagerStopScan", map);
                             }
                         }

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -146,7 +146,7 @@ public class LollipopScanManager extends ScanManager {
 		@Override
 		public void onScanFailed(final int errorCode) {
             WritableMap map = Arguments.createMap();
-						map.putInt("reason", errorCode);
+						map.putInt("status", errorCode);
             bleManager.sendEvent("BleManagerStopScan", map);
 		}
 	};

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -101,6 +101,7 @@ public class LollipopScanManager extends ScanManager {
                                     btAdapter.getBluetoothLeScanner().stopScan(mScanCallback);
                                 }
                                 WritableMap map = Arguments.createMap();
+																map.putInt("reason", 0);
                                 bleManager.sendEvent("BleManagerStopScan", map);
                             }
                         }
@@ -145,6 +146,7 @@ public class LollipopScanManager extends ScanManager {
 		@Override
 		public void onScanFailed(final int errorCode) {
             WritableMap map = Arguments.createMap();
+						map.putInt("reason", errorCode);
             bleManager.sendEvent("BleManagerStopScan", map);
 		}
 	};

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -101,7 +101,7 @@ public class LollipopScanManager extends ScanManager {
                                     btAdapter.getBluetoothLeScanner().stopScan(mScanCallback);
                                 }
                                 WritableMap map = Arguments.createMap();
-																map.putInt("reason", 0);
+																map.putInt("reason", 10);
                                 bleManager.sendEvent("BleManagerStopScan", map);
                             }
                         }

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -378,7 +378,7 @@ RCT_EXPORT_METHOD(stopScan:(nonnull RCTResponseSenderBlock)callback)
     }
     [manager stopScan];
     if (hasListeners) {
-        [self sendEventWithName:@"BleManagerStopScan" body:@{}];
+				[self sendEventWithName:@"BleManagerStopScan" body:@{@"status": @0}];
     }
     callback(@[[NSNull null]]);
 }
@@ -390,7 +390,7 @@ RCT_EXPORT_METHOD(stopScan:(nonnull RCTResponseSenderBlock)callback)
     [manager stopScan];
     if (hasListeners) {
         if (self.bridge) {
-            [self sendEventWithName:@"BleManagerStopScan" body:@{}];
+            [self sendEventWithName:@"BleManagerStopScan" body:@{@"status": @10}];
         }
     }
 }


### PR DESCRIPTION
Needed this field to add some defensive error handling for a few android devices that returns `SCAN_FAILED_ALREADY_STARTED` sometimes.

Ref.
https://developer.android.com/reference/android/bluetooth/le/ScanCallback#SCAN_FAILED_ALREADY_STARTED

I was not sure how to handle the scenarios where an error message was not provided by the OS, so I just returned 0 for those scenarios. It seems like iOS does not provide that much similar information at least from what I could find

https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518986-scanforperipherals