### PR TITLE
Write callback NPE fix

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -832,7 +832,7 @@ public class Peripheral extends BluetoothGattCallback {
 					else
 						writeCallback = null;
 					if (!gatt.writeCharacteristic(characteristic)) {
-						sendBackrError(writeCallback, "Write failed");
+						sendBackrError(callback, "Write failed");
 						writeCallback = null;
 						completedCommand();
 					}


### PR DESCRIPTION
This change fixes two possible null pointer exceptions that result from passing a null reference to `sendBackrError` which invokes the passed callback without performing a null check.
- Peripheral.java line 835 `writeCallback` can be set to null if a write without response is performed.
- If a disconnect occurs before `writeCallback` is invoked, in which case `writeCallback` can be assigned to null in Peripheral.java line 344.

Note that many NPEs can happen as a result of a lack of thread safety when accessing the `gatt` object, especially during disconnects.  I've been working on a fix [here](https://github.com/TraFriTCR/react-native-ble-manager/tree/android-thread-safety-enhancements).  Feel free to incorporate this, otherwise I will make some more changes and do more testing before making a pull request.