### PR TITLE
feat (android ble scan) support callbackType scan setting

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -264,6 +264,13 @@ class BleManager {
       if (scanningOptions.scanMode == null) {
         scanningOptions.scanMode = 0;
       }
+      
+      // (ANDROID) Defaults to CALLBACK_TYPE_ALL_MATCHES 
+      // WARN: sometimes, setting a scanSetting instead of leaving it untouched might result in unexpected behaviors.
+      // https://github.com/dariuszseweryn/RxAndroidBle/issues/462
+      if (scanningOptions.callbackType == null) {
+        scanningOptions.callbackType = 1;
+      }
 
       if (scanningOptions.reportDelay == null) {
         scanningOptions.reportDelay = 0;

--- a/BleManager.js
+++ b/BleManager.js
@@ -250,7 +250,7 @@ class BleManager {
       }
 
       // (ANDROID) Match as many advertisement per filter as hw could allow
-      // dependes on current capability and availability of the resources in hw.
+      // depends on current capability and availability of the resources in hw.
       if (scanningOptions.numberOfMatches == null) {
         scanningOptions.numberOfMatches = 3;
       }
@@ -260,7 +260,7 @@ class BleManager {
         scanningOptions.matchMode = 1;
       }
 
-      // (ANDROID) Defaults to SCAN_MODE_LOW_POWER on android
+      // (ANDROID) Defaults to SCAN_MODE_LOW_POWER
       if (scanningOptions.scanMode == null) {
         scanningOptions.scanMode = 0;
       }
@@ -272,6 +272,7 @@ class BleManager {
         scanningOptions.callbackType = 1;
       }
 
+      // (ANDROID) Defaults to 0ms (report results immediately).
       if (scanningOptions.reportDelay == null) {
         scanningOptions.reportDelay = 0;
       }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ BleManager.start({ showAlert: false }).then(() => {
 
 ### scan(serviceUUIDs, seconds, allowDuplicates, scanningOptions)
 
-Scan for availables peripherals.
+Scan for available peripherals.
 Returns a `Promise` object.
 
 **Arguments**
@@ -131,10 +131,11 @@ Returns a `Promise` object.
 - `seconds` - `Integer` - the amount of seconds to scan.
 - `allowDuplicates` - `Boolean` - [iOS only] allow duplicates in device scanning
 - `scanningOptions` - `JSON` - [Android only] after Android 5.0, user can control specific ble scan behaviors:
-  - `numberOfMatches` - `Number` - [Android only] corresponding to [`setNumOfMatches`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setNumOfMatches(int)>)
-  - `matchMode` - `Number` - [Android only] corresponding to [`setMatchMode`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setMatchMode(int)>)
-  - `scanMode` - `Number` - [Android only] corresponding to [`setScanMode`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setScanMode(int)>)
-  - `reportDelay` - `Number` - [Android only] corresponding to [`setReportDelay`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setReportDelay(long)>)
+  - `numberOfMatches` - `Number` - [Android only] corresponding to [`setNumOfMatches`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setNumOfMatches(int)>). Defaults to `ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT`.
+  - `matchMode` - `Number` - [Android only] corresponding to [`setMatchMode`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setMatchMode(int)>). Defaults to `ScanSettings.MATCH_MODE_AGGRESSIVE`.
+  - `callbackType` - `Number` - [Android only] corresponding to [`setCallbackType`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setCallbackType(int)>). Defaults `ScanSettings.CALLBACK_TYPE_ALL_MATCHES`.
+  - `scanMode` - `Number` - [Android only] corresponding to [`setScanMode`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setScanMode(int)>). Defaults to `ScanSettings.SCAN_MODE_LOW_POWER`.
+  - `reportDelay` - `Number` - [Android only] corresponding to [`setReportDelay`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setReportDelay(long)>). Defaults to `0ms`.
   - `phy` - `Number` - [Android only] corresponding to [`setPhy`](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setPhy(int))
   - `legacy` - `Boolean` - [Android only] corresponding to [`setLegacy`](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean))
 

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -54,6 +54,9 @@ public class LollipopScanManager extends ScanManager {
             if (options.hasKey("matchMode")) {
                 scanSettingsBuilder.setMatchMode(options.getInt("matchMode"));
             }
+            if (options.hasKey("callbackType")) {
+                scanSettingsBuilder.setCallbackType(options.getInt("callbackType"));
+            }
         }
 
         if (options.hasKey("reportDelay")) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module "react-native-ble-manager" {
   export interface ScanOptions {
     numberOfMatches?: number;
     matchMode?: number;
+    callbackType?: number;
     scanMode?: number;
     reportDelay?: number;
     phy?: number;


### PR DESCRIPTION
Hi, among the scan settings introduced by android on M, this repo maps most but lacks `callbackType` [as documented here](https://developer.android.com/reference/android/bluetooth/le/ScanSettings#CALLBACK_TYPE_ALL_MATCHES).

While trying to figure out what is working wrong with BLE scans on android 13 I tried to set this scan setting myself, so I figured I'd add it to the lib in case it helps anyone.

This setting basically enables android to optionally have a "notify once" behavior for each scanned device, sort of like ios `allowDuplicates`. The tradeoff being we might not have full data on a device when it pops. It also supports another mode (notify on match lost) that is rarely useful.

The default mode I left is the one already enabled by default and supported by this library implementation (update data on peripheral every time it is provided to `onScanResult`).

A few important notes:

-  each time we modify the default scan settings, we might alter the behavior of the underlying implementation. [This is documented here](https://github.com/dariuszseweryn/RxAndroidBle/issues/462) for example, very obscure behavior stuff, but I think the scan behavior might be different if this lib enabled to NOT set anything by default in scan settings, and let the underlying implementation do its magic. For reference, [Nordic lib actually does this](https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library/blob/120cc5edb86ecb9b63f50a764a8334f3c805d5e6/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java#L132) and exposes a "dumb" `scan` method.

- in the current version of the scan implementation, there is an undocumented behavior change depending on if there is a scan filter (the only one implemented currently is ServiceUUIDs) or not. Since android 8.1, [scan requests without filters will be put on hold](https://stackoverflow.com/questions/48077690/ble-scan-is-not-working-when-screen-is-off-on-android-8-1-0) as soon as the app is not in foreground or screen turns off (and I assume this might be true even if the proper permissions are added to the manifest for background scanning).

- the default for scan mode (LOW_POWER) does not seem appropriate to me, as this mode will probably miss much more devices than the LOW_LATENCY one : in low power mode, the phone only listen 0.5s every 5s, so depending on the beacon / bluetooth device advertising frequency, it might take much longer to detect or even not detect at lot if the advertising frequency pops out of the 0.5s range every time. [Source here](https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02).

