### PR TITLE
feat (android scan) support scan filter by exact advertising name

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Returns a `Promise` object.
   - `reportDelay` - `Number` - [Android only] corresponding to [`setReportDelay`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder.html#setReportDelay(long)>). Defaults to `0ms`.
   - `phy` - `Number` - [Android only] corresponding to [`setPhy`](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setPhy(int))
   - `legacy` - `Boolean` - [Android only] corresponding to [`setLegacy`](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean))
+  - `exactAdvertisingName` - `string` - [Android only] corresponds to the `ScanFilter` [deviceName](https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String))
 
 **Examples**
 

--- a/android/src/main/java/it/innove/LollipopScanManager.java
+++ b/android/src/main/java/it/innove/LollipopScanManager.java
@@ -92,7 +92,15 @@ public class LollipopScanManager extends ScanManager {
             }
         }
 
+        if (options.hasKey("exactAdvertisingName")) {
+            String expectedName = options.getString("exactAdvertisingName");
+            Log.d(BleManager.LOG_TAG, "Filter on advertising name:" + expectedName);
+            ScanFilter filter = new ScanFilter.Builder().setDeviceName(expectedName).build();
+            filters.add(filter);
+        }
+
         getBluetoothAdapter().getBluetoothLeScanner().startScan(filters, scanSettingsBuilder.build(), mScanCallback);
+
         if (scanSeconds > 0) {
             Thread thread = new Thread() {
                 private int currentScanSession = scanSessionId.incrementAndGet();
@@ -109,11 +117,13 @@ public class LollipopScanManager extends ScanManager {
                         @Override
                         public void run() {
                             BluetoothAdapter btAdapter = getBluetoothAdapter();
+
                             // check current scan session was not stopped
                             if (scanSessionId.intValue() == currentScanSession) {
                                 if (btAdapter.getState() == BluetoothAdapter.STATE_ON) {
                                     btAdapter.getBluetoothLeScanner().stopScan(mScanCallback);
                                 }
+
                                 WritableMap map = Arguments.createMap();
                                 map.putInt("status", 10);
                                 bleManager.sendEvent("BleManagerStopScan", map);

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,13 @@ class BleManager {
         scanningOptions.reportDelay = 0;
       }
 
+      // (ANDROID) ScanFilter used to restrict search to devices with a specific advertising name.
+      // https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
+      if (!scanningOptions.exactAdvertisingName
+        || typeof scanningOptions.exactAdvertisingName !== 'string') {
+        delete scanningOptions.exactAdvertisingName;
+      }
+
       bleManager.scan(
         serviceUUIDs,
         seconds,

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,15 @@ export interface ScanOptions {
    * https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)
    */
   legacy?: boolean;
+  /**
+   * an android ScanFilter, used if present to restrict scan results to devices with a specific advertising name.
+   * This is a whole word match, not a partial search.
+   * Use with caution, it's behavior is tricky and seems to be the following: 
+   * if `callbackType` is set to `AllMatches`, only the completeLocalName will be used for filtering.
+   * if `callbackType` is set to `FirstMatch`, the shortenedLocalName will be used for filtering.
+   * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
+   */
+  exactAdvertisingName?: string;
 }
 
 /**


### PR DESCRIPTION
- added as a new option in scanOptions to make it backward compatible