### PR TITLE
feat (checkState) checkState method now resolves to the current BLE state

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,12 +261,13 @@ BleManager.enableBluetooth()
 
 ### checkState()
 
-Force the module to check the state of BLE and trigger a BleManagerDidUpdateState event.
+Force the module to check the state of the native BLE manager and trigger a BleManagerDidUpdateState event.
+Resolves to a promise containing the current BleState.
 
 **Examples**
 
 ```js
-BleManager.checkState();
+BleManager.checkState().then(state => console.log(`current BLE state = '${state}'.`));
 ```
 
 ### startNotification(peripheralId, serviceUUID, characteristicUUID)

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -457,7 +457,7 @@ class BleManager extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void checkState() {
+    public void checkState(Callback callback) {
         Log.d(LOG_TAG, "checkState");
 
         BluetoothAdapter adapter = getBluetoothAdapter();
@@ -489,6 +489,7 @@ class BleManager extends ReactContextBaseJavaModule {
         map.putString("state", state);
         Log.d(LOG_TAG, "state:" + state);
         sendEvent("BleManagerDidUpdateState", map);
+        callback.invoke(state);
     }
 
     @ReactMethod

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -146,17 +146,17 @@ bool hasListeners;
 - (NSString *) centralManagerStateToString: (int)state
 {
     switch (state) {
-        case CBCentralManagerStateUnknown:
+        case CBManagerStateUnknown:
             return @"unknown";
-        case CBCentralManagerStateResetting:
+        case CBManagerStateResetting:
             return @"resetting";
-        case CBCentralManagerStateUnsupported:
+        case CBManagerStateUnsupported:
             return @"unsupported";
-        case CBCentralManagerStateUnauthorized:
+        case CBManagerStateUnauthorized:
             return @"unauthorized";
-        case CBCentralManagerStatePoweredOff:
+        case CBManagerStatePoweredOff:
             return @"off";
-        case CBCentralManagerStatePoweredOn:
+        case CBManagerStatePoweredOn:
             return @"on";
         default:
             return @"unknown";
@@ -186,12 +186,18 @@ bool hasListeners;
 - (NSString *) periphalManagerStateToString: (int)state
 {
     switch (state) {
-        case CBPeripheralManagerStateUnknown:
-            return @"Unknown";
-        case CBPeripheralManagerStatePoweredOn:
-            return @"PoweredOn";
-        case CBPeripheralManagerStatePoweredOff:
-            return @"PoweredOff";
+        case CBManagerStateUnknown:
+            return @"unknown";
+        case CBManagerStateResetting:
+            return @"resetting";
+        case CBManagerStateUnsupported:
+            return @"unsupported";
+        case CBManagerStateUnauthorized:
+            return @"unauthorized";
+        case CBManagerStatePoweredOff:
+            return @"off";
+        case CBManagerStatePoweredOn:
+            return @"on";
         default:
             return @"unknown";
     }
@@ -469,10 +475,13 @@ RCT_EXPORT_METHOD(disconnect:(NSString *)peripheralUUID force:(BOOL)force callba
     }
 }
 
-RCT_EXPORT_METHOD(checkState)
+RCT_EXPORT_METHOD(checkState:(nonnull RCTResponseSenderBlock)callback)
 {
     if (manager != nil){
         [self centralManagerDidUpdateState:self.manager];
+
+        NSString *stateName = [self centralManagerStateToString:self.manager.state];
+        callback(@[stateName]);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   BleScanMatchCount,
   BleScanMatchMode,
   BleScanMode,
+  BleState,
   ConnectionPriority,
   Peripheral,
   PeripheralInfo,
@@ -304,7 +305,11 @@ class BleManager {
   }
 
   checkState() {
-    bleManager.checkState();
+    return new Promise<BleState>((fulfill, _) => {
+      bleManager.checkState((state: BleState) => {
+        fulfill(state);
+      });
+    });
   }
 
   start(options?: StartOptions) {


### PR DESCRIPTION
- ios: fix deprecated use of CBCentralManager for state mapping