### PR TITLE
fix: conform ios native data to match the typescript model

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -95,7 +95,7 @@ bool hasListeners;
         [self invokeAndClearDictionary:readCallbacks withKey:key usingParameters:@[[NSNull null], ([characteristic.value length] > 0) ? [characteristic.value toArray] : [NSNull null]]];
     } else {
         if (hasListeners) {
-            [self sendEventWithName:@"BleManagerDidUpdateValueForCharacteristic" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic":characteristic.UUID.UUIDString, @"service":characteristic.service.UUID.UUIDString, @"value": ([characteristic.value length] > 0) ? [characteristic.value toArray] : [NSNull null]}];
+            [self sendEventWithName:@"BleManagerDidUpdateValueForCharacteristic" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic":characteristic.UUID.UUIDString.lowercaseString, @"service":characteristic.service.UUID.UUIDString.lowercaseString, @"value": ([characteristic.value length] > 0) ? [characteristic.value toArray] : [NSNull null]}];
         }
     }
 }
@@ -107,7 +107,7 @@ bool hasListeners;
             return;
         }
         if (hasListeners) {
-            [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(false), @"domain": [error domain], @"code": @(error.code)}];
+            [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString.lowercaseString, @"isNotifying": @(false), @"domain": [error domain], @"code": @(error.code)}];
         }
     }
     
@@ -136,7 +136,7 @@ bool hasListeners;
         }
     }
     if (hasListeners) {
-        [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString, @"isNotifying": @(characteristic.isNotifying)}];
+        [self sendEventWithName:@"BleManagerDidUpdateNotificationStateFor" body:@{@"peripheral": peripheral.uuidAsString, @"characteristic": characteristic.UUID.UUIDString.lowercaseString, @"isNotifying": @(characteristic.isNotifying)}];
     }
 }
 
@@ -211,7 +211,7 @@ bool hasListeners;
     @synchronized(peripherals) {
         for (CBPeripheral *p in peripherals) {
             
-            NSString* other = p.identifier.UUIDString;
+            NSString* other = p.identifier.UUIDString.lowercaseString;
             
             if ([uuid isEqualToString:other]) {
                 peripheral = p;
@@ -878,7 +878,7 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     for(int i=0; i < service.characteristics.count; i++)
     {
         CBCharacteristic *c = [service.characteristics objectAtIndex:i];
-        if ((c.properties & prop) != 0x0 && [c.UUID.UUIDString isEqualToString: UUID.UUIDString]) {
+        if ((c.properties & prop) != 0x0 && [c.UUID.UUIDString.lowercaseString isEqualToString: UUID.UUIDString.lowercaseString]) {
             NSLog(@"Found %@", UUID);
             return c;
         }
@@ -893,7 +893,7 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     for(int i=0; i < service.characteristics.count; i++)
     {
         CBCharacteristic *c = [service.characteristics objectAtIndex:i];
-        if ([c.UUID.UUIDString isEqualToString: UUID.UUIDString]) {
+        if ([c.UUID.UUIDString.lowercaseString isEqualToString: UUID.UUIDString.lowercaseString]) {
             NSLog(@"Found %@", UUID);
             return c;
         }
@@ -931,10 +931,10 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     {
         NSString* err = [NSString stringWithFormat:@"Could not find service with UUID %@ on peripheral with UUID %@",
                          serviceUUIDString,
-                         peripheral.identifier.UUIDString];
+                         peripheral.identifier.UUIDString.lowercaseString];
         NSLog(@"Could not find service with UUID %@ on peripheral with UUID %@",
               serviceUUIDString,
-              peripheral.identifier.UUIDString);
+              peripheral.identifier.UUIDString.lowercaseString);
         callback(@[err]);
         return nil;
     }
@@ -953,11 +953,11 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     
     if (!characteristic)
     {
-        NSString* err = [NSString stringWithFormat:@"Could not find characteristic with UUID %@ on service with UUID %@ on peripheral with UUID %@", characteristicUUIDString,serviceUUIDString, peripheral.identifier.UUIDString];
+        NSString* err = [NSString stringWithFormat:@"Could not find characteristic with UUID %@ on service with UUID %@ on peripheral with UUID %@", characteristicUUIDString,serviceUUIDString, peripheral.identifier.UUIDString.lowercaseString];
         NSLog(@"Could not find characteristic with UUID %@ on service with UUID %@ on peripheral with UUID %@",
               characteristicUUIDString,
               serviceUUIDString,
-              peripheral.identifier.UUIDString);
+              peripheral.identifier.UUIDString.lowercaseString);
         callback(@[err]);
         return nil;
     }

--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -8,7 +8,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
 
 -(NSString *)uuidAsString {
   if (self.identifier.UUIDString) {
-    return self.identifier.UUIDString;
+    return [self.identifier.UUIDString lowercaseString];
   } else {
     return @"";
   }
@@ -18,7 +18,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
 -(NSDictionary *)asDictionary {
   NSString *uuidString = NULL;
   if (self.identifier.UUIDString) {
-    uuidString = self.identifier.UUIDString;
+    uuidString = [self.identifier.UUIDString lowercaseString];
   } else {
     uuidString = @"";
   }
@@ -112,7 +112,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     
     for (CBUUID *key in [serviceData allKeys]) {
         if ([serviceData objectForKey:key]) {
-            [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
+            [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[[key UUIDString] lowercaseString]];
             [serviceData removeObjectForKey:key];
         }
     }
@@ -129,7 +129,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     serviceUUIDStrings = [[NSMutableArray alloc] initWithCapacity:serviceUUIDs.count];
     
     for (CBUUID *uuid in serviceUUIDs) {
-      [serviceUUIDStrings addObject:[uuid UUIDString]];
+      [serviceUUIDStrings addObject:[[uuid UUIDString] lowercaseString]];
     }
     
     // replace the UUID list with list of strings
@@ -145,7 +145,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     solicitiedServiceUUIDStrings = [[NSMutableArray alloc] initWithCapacity:solicitiedServiceUUIDs.count];
     
     for (CBUUID *uuid in solicitiedServiceUUIDs) {
-      [solicitiedServiceUUIDStrings addObject:[uuid UUIDString]];
+      [solicitiedServiceUUIDStrings addObject:[[uuid UUIDString] lowercaseString]];
     }
     
     // replace the UUID list with list of strings
@@ -161,7 +161,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     overflowServiceUUIDStrings = [[NSMutableArray alloc] initWithCapacity:overflowServiceUUIDs.count];
 
     for (CBUUID *uuid in overflowServiceUUIDs) {
-      [overflowServiceUUIDStrings addObject:[uuid UUIDString]];
+      [overflowServiceUUIDStrings addObject:[[uuid UUIDString] lowercaseString]];
     }
 
     // replace the UUID list with list of strings
@@ -188,11 +188,13 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
   
   // This can move into the CBPeripherial Extension
   for (CBService *service in [self services]) {
-    [serviceList addObject:[[service UUID] UUIDString]];
+    NSMutableDictionary *serviceDictionary = [NSMutableDictionary new];
+    [serviceDictionary setObject:[[[service UUID] UUIDString] lowercaseString] forKey:@"uuid"];
+    [serviceList addObject:serviceDictionary];
     for (CBCharacteristic *characteristic in service.characteristics) {
       NSMutableDictionary *characteristicDictionary = [NSMutableDictionary new];
-      [characteristicDictionary setObject:[[service UUID] UUIDString] forKey:@"service"];
-      [characteristicDictionary setObject:[[characteristic UUID] UUIDString] forKey:@"characteristic"];
+      [characteristicDictionary setObject:[[[service UUID] UUIDString] lowercaseString] forKey:@"service"];
+      [characteristicDictionary setObject:[[[characteristic UUID] UUIDString] lowercaseString] forKey:@"characteristic"];
       
       if ([characteristic value] && [[characteristic value] length] > 0) {
         [characteristicDictionary setObject:dataToArrayBuffer([characteristic value]) forKey:@"value"];
@@ -209,7 +211,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
       NSMutableArray *descriptorList = [NSMutableArray new];
       for (CBDescriptor *descriptor in characteristic.descriptors) {
         NSMutableDictionary *descriptorDictionary = [NSMutableDictionary new];
-        [descriptorDictionary setObject:[[descriptor UUID] UUIDString] forKey:@"descriptor"];
+        [descriptorDictionary setObject:[[[descriptor UUID] UUIDString] lowercaseString] forKey:@"uuid"];
         if ([descriptor value]) { // should always have a value?
           [descriptorDictionary setObject:[descriptor value] forKey:@"value"];
         }
@@ -227,50 +229,50 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
   
 }
 
--(NSArray *) decodeCharacteristicProperties: (CBCharacteristic *) characteristic {
-  NSMutableArray *props = [NSMutableArray new];
+-(NSDictionary *) decodeCharacteristicProperties: (CBCharacteristic *) characteristic {
+  NSMutableDictionary *props = [NSMutableDictionary new];
   
   CBCharacteristicProperties p = [characteristic properties];
   
   // NOTE: props strings need to be consistent across iOS and Android
   if ((p & CBCharacteristicPropertyBroadcast) != 0x0) {
-    [props addObject:@"Broadcast"];
+    [props setValue:@"Broadcast" forKey:@"Broadcast"];
   }
   
   if ((p & CBCharacteristicPropertyRead) != 0x0) {
-    [props addObject:@"Read"];
+    [props setValue:@"Read" forKey:@"Read"];
   }
   
   if ((p & CBCharacteristicPropertyWriteWithoutResponse) != 0x0) {
-    [props addObject:@"WriteWithoutResponse"];
+    [props setValue:@"WriteWithoutResponse" forKey:@"WriteWithoutResponse"];
   }
   
   if ((p & CBCharacteristicPropertyWrite) != 0x0) {
-    [props addObject:@"Write"];
+    [props setValue:@"Write" forKey:@"Write"];
   }
   
   if ((p & CBCharacteristicPropertyNotify) != 0x0) {
-    [props addObject:@"Notify"];
+    [props setValue:@"Notify" forKey:@"Notify"];
   }
   
   if ((p & CBCharacteristicPropertyIndicate) != 0x0) {
-    [props addObject:@"Indicate"];
+    [props setValue:@"Indicate" forKey:@"Indicate"];
   }
   
   if ((p & CBCharacteristicPropertyAuthenticatedSignedWrites) != 0x0) {
-    [props addObject:@"AuthenticateSignedWrites"];
+    [props setValue:@"AuthenticateSignedWrites" forKey:@"AuthenticateSignedWrites"];
   }
   
   if ((p & CBCharacteristicPropertyExtendedProperties) != 0x0) {
-    [props addObject:@"ExtendedProperties"];
+    [props setValue:@"ExtendedProperties" forKey:@"ExtendedProperties"];
   }
   
   if ((p & CBCharacteristicPropertyNotifyEncryptionRequired) != 0x0) {
-    [props addObject:@"NotifyEncryptionRequired"];
+    [props setValue:@"NotifyEncryptionRequired" forKey:@"NotifyEncryptionRequired"];
   }
   
   if ((p & CBCharacteristicPropertyIndicateEncryptionRequired) != 0x0) {
-    [props addObject:@"IndicateEncryptionRequired"];
+    [props setValue:@"IndicateEncryptionRequired" forKey:@"IndicateEncryptionRequired"];
   }
   
   return props;


### PR DESCRIPTION
iOS and android data returned from native to js was quite different. This PR attempts to resolve it by correcting iOS native code
Another behaviour observed was iOS converts uuid to string in upper case which is actually a wrong behaviour as per https://www.itu.int/rec/T-REC-X.667/en
Android handles it correctly.
So to conform to the standard and to maintain uniformity all uuid strings are converted to lowercase.

Since this involves data structure changes, I believe this will become a breaking change for those who are using work arounds based on platform os.