### PR TITLE
Fix: Restore peripheral write capability

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -360,7 +360,7 @@ class BleManager extends ReactContextBaseJavaModule {
         if (peripheral != null) {
             byte[] decoded = new byte[message.size()];
             for (int i = 0; i < message.size(); i++) {
-                decoded[i] = Integer.valueOf(i).byteValue();
+                decoded[i] = Integer.valueOf(message.getInt(i)).byteValue();
             }
             Log.d(LOG_TAG, "Message(" + decoded.length + "): " + bytesToHex(decoded));
             peripheral.write(UUIDHelper.uuidFromString(serviceUUID), UUIDHelper.uuidFromString(characteristicUUID),
@@ -381,7 +381,7 @@ class BleManager extends ReactContextBaseJavaModule {
         if (peripheral != null) {
             byte[] decoded = new byte[message.size()];
             for (int i = 0; i < message.size(); i++) {
-                decoded[i] = Integer.valueOf(i).byteValue();
+              decoded[i] = Integer.valueOf(message.getInt(i)).byteValue();
             }
             Log.d(LOG_TAG, "Message(" + decoded.length + "): " + bytesToHex(decoded));
             peripheral.write(UUIDHelper.uuidFromString(serviceUUID), UUIDHelper.uuidFromString(characteristicUUID),

--- a/android/src/main/java/it/innove/BundleJSONConverter.java
+++ b/android/src/main/java/it/innove/BundleJSONConverter.java
@@ -127,7 +127,7 @@ public class BundleJSONConverter {
 		JSONObject json = new JSONObject();
 
 		for(String key : bundle.keySet()) {
-			Object value = bundle.getString(key);
+			Object value = bundle.get(key);
 			if (value == null) {
 				// Null is not supported.
 				continue;


### PR DESCRIPTION
Release 10.1.0 broke my ability to write to peripherals.  This was a breaking change from 10.0.2 which worked OK. Upon review of the code changes between the versions I found three suspect lines of code that were modified to the detriment of the write capability.  The changes in BleManager.java were the main culprit with the message contents ignored when assembling a message to write.

A second suspicious change BundleJSONConverter.java was also restored to the previous version.  The 10.0.2 version was using bundle.get() and then checking the type and doing casts to various types.  The 10.1.0 version was using getString and then attempting the same casts.  This seemed wrong to me to request a string and the cast it to a List so I restored the previous version.

With these fixes I am now able to write to peripherals again.