### PR TITLE
fixing duplicate symbol hasListeners

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -17,7 +17,7 @@ RCT_EXPORT_MODULE();
 @synthesize manager;
 @synthesize peripherals;
 @synthesize scanTimer;
-bool hasListeners;
+static bool hasListeners = NO;
 
 - (instancetype)init
 {


### PR DESCRIPTION
I got a report [on my lib ](https://github.com/RonRadtke/react-native-blob-util/issues/253) about a duplicate symbol.
I fixed it on my side, but since it can happen with other libs too I think it would be worth fixing it here too.