### PR TITLE
fix(BleManager): type warning

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -185,7 +185,7 @@ static bool hasListeners = NO;
 
 
 
-- (NSString *) centralManagerStateToString: (int)state
+- (NSString *) centralManagerStateToString: (CBManagerState)state
 {
     switch (state) {
         case CBManagerStateUnknown:

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -972,7 +972,6 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
     }
     NSLog(@"Characteristics For Service Discover");
     
-    NSString *peripheralUUIDString = [peripheral uuidAsString];
     NSMutableSet *characteristicsForService = [NSMutableSet new];
     [characteristicsForService addObjectsFromArray:service.characteristics];
     [retrieveServicesLatches setObject:characteristicsForService forKey:service.UUID.UUIDString];


### PR DESCRIPTION
Hi there! I'm currently focused on improving my iOS development skills, and to achieve this, I've been reading and experimenting with some native code. While going through this library, I encountered two typing warnings that I attempted to resolve. I would greatly appreciate it if you could let me know if my solution was the correct approach. Thank you.

Fix: 
- Remove the unused variable `peripheralUUIDString` in the function `didDiscoverCharacteristicsForService`
- Update the prop type of `centralManagerStateToString` from `int` to `CBManagerState`
