### PR TITLE
Update BleManager.java

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -175,7 +175,15 @@ class BleManager extends ReactContextBaseJavaModule {
             if (getCurrentActivity() == null)
                 callback.invoke("Current activity not available");
             else
-                getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
+                {
+                    try{
+                        getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
+                    }catch{
+                        callback.invoke("Current activity not available");
+                    }
+                    
+                }
+                
         } else
             callback.invoke();
     }


### PR DESCRIPTION
introduced a try catch block for vivo phones since it crash when we try to do getCurrentActivity.startActivityForResult.

so did with a try catch block to catch that and stop it from crashing the app 