### PR TITLE
Fix serviceData type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface AdvertisingData {
   isConnectable?: boolean;
   localName?: string;
   manufacturerData?: CustomAdvertisingData;
-  serviceData?: CustomAdvertisingData;
+  serviceData?: Record<string, CustomAdvertisingData>;
   serviceUUIDs?: string[];
   txPowerLevel?: number;
 }
@@ -76,7 +76,7 @@ export interface StartOptions {
   forceLegacy?: boolean;
 }
 
-export interface ConnectOptions {  
+export interface ConnectOptions {
   /**
    * [android only]
    */


### PR DESCRIPTION
Native code puts data in map based on service uuids. Probably this property could be also required but I am not 100% sure if it is always empty object if no service data is present.