### PR TITLE
Fix buffer

### DIFF
--- a/android/src/main/java/it/innove/NotifyBufferContainer.java
+++ b/android/src/main/java/it/innove/NotifyBufferContainer.java
@@ -12,18 +12,21 @@ public class NotifyBufferContainer {
         this.items.clear();
     }
     public byte[] put(byte[] value){
-        int restLength = value.length - this.items.remaining();
         byte[] toInsert = null;
         byte[] rest = null;
-        if (restLength>0) {          
+        
+        if (value.length > this.items.remaining()) {
+            int restLength = value.length - this.items.remaining();
             rest = new byte[restLength];
             toInsert = new byte[this.items.remaining()];
             System.arraycopy(value, 0, toInsert, 0, toInsert.length);
-            System.arraycopy(value, toInsert.length, rest, restLength, rest.length);
+            System.arraycopy(value, toInsert.length, rest, 0, rest.length);
         } else {
             toInsert = value;
         }
+        
         this.items.put(toInsert);
+
         return rest;
     }
     public boolean isBufferFull(){


### PR DESCRIPTION
From the documentation, I understand that the logic should be this (you can run the code on the website
https://www.jdoodle.com/online-java-compiler/)

```java
import java.nio.ByteBuffer;

public class MyClass {
  public static void main(String args[]) {
     ByteBuffer items = ByteBuffer.allocate(5);
     
     byte[] init = {0};
     byte[] value = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     byte[] toInsert = null;
     byte[] rest = null;

     // initial values
     items.put(init);
      
     if (value.length > items.remaining()) {
        int restLength = value.length - items.remaining();
        rest = new byte[restLength];
        toInsert = new byte[items.remaining()];
        System.arraycopy(value, 0, toInsert, 0, toInsert.length);
        System.arraycopy(value, toInsert.length, rest, 0, rest.length);
     } else {
        toInsert = value;
     }
     
        System.out.println("toInsert");
        for (int i = 0; i < toInsert.length; i++) {
            System.out.println(i + ": " + toInsert[i]);
        }

        System.out.println("rest");
        for (int i = 0; i < rest.length; i++) {
            System.out.println(i + ": " + rest[i]);
        }
   }
}
```

The array has size 5 and I already have 1 value so it should only accept 4 more values to complete the buffer and the other values are returned.

```
toInsert
0: 1
1: 2
2: 3
3: 4
rest
0: 5
1: 6
2: 7
3: 8
4: 9
5: 10
6: 11
```