### PR TITLE
Set peripheral delegate when restoring state

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -1148,6 +1148,7 @@ RCT_EXPORT_METHOD(requestMTU:(NSString *)deviceUUID mtu:(NSInteger)mtu callback:
             NSMutableArray *data = [NSMutableArray new];
             for (CBPeripheral *peripheral in peripherals) {
                 [data addObject:[peripheral asDictionary]];
+		peripheral.delegate = self;
             }
 
             [self sendEventWithName:@"BleManagerCentralManagerWillRestoreState" body:@{@"peripherals": data}];


### PR DESCRIPTION
I noticed when setting up handling events in the background that we did not receive the events for updateCharacteristics etc. After some digging it turns out that the delegate for the connected peripherals is not set, and as far as I have found, connecting when the react-native code is running seems to be too late to receive the characteristics update. 

Turns out that setting `peripheral.manager = self` in the `willRestoreState` handler solved the issue, and all events end up in our typescript handlers.

Should resolve #1035