### PR TITLE
improve docs on iOS app with deployment target older than 13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If you need communication while the app is not in the foreground you need the "A
 ##### iOS - Update Info.plist
 
 In iOS >= 13 you need to add the `NSBluetoothAlwaysUsageDescription` string key.
+If the deployment target is earlier than iOS 13, you also need to add the `NSBluetoothPeripheralUsageDescription` string key.
 
 ## Note
 


### PR DESCRIPTION
For Apps with an Deployment target of 12.4 (default in RN 0.72) another key is needed in the plist ("NSBluetoothPeripheralUsageDescription").
Adding this to the Readme might be helpful because most devs have to do that.

Source: 
`"If your app has a deployment target earlier than iOS 13, add the NSBluetoothPeripheralUsageDescription key to your app’s Information Property List file in addition to this key."`
https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothalwaysusagedescription#discussion