### PR TITLE
[RFC] Implement companion device manager support

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -833,8 +833,8 @@ class BleManager extends ReactContextBaseJavaModule {
         for (String association : manager.getAssociations()) {
             if (association.equals(address)) {
                 manager.disassociate(address);
-                callback.invoke(null);
-                break;
+                callback.invoke();
+                return;
             }
         }
 

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -2,7 +2,6 @@ package it.innove;
 
 import static android.app.Activity.RESULT_OK;
 import static android.bluetooth.BluetoothProfile.GATT;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -10,6 +9,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothManager;
+import android.companion.CompanionDeviceManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -19,6 +19,7 @@ import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -71,7 +72,10 @@ class BleManager extends ReactContextBaseJavaModule {
     private BondRequest bondRequest;
     private BondRequest removeBondRequest;
     private boolean forceLegacy;
-
+    /**
+     * Used for companion scanning, if supported.
+     */
+    private final @Nullable CompanionScanner companionScanner;
     public static ReadableMap moduleOptions;
 
     public ReactApplicationContext getReactContext() {
@@ -103,6 +107,13 @@ class BleManager extends ReactContextBaseJavaModule {
         super(reactContext);
         context = reactContext;
         this.reactContext = reactContext;
+
+        boolean supportsCompanion = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_COMPANION_DEVICE_SETUP);
+        this.companionScanner = supportsCompanion
+                ? new CompanionScanner(reactContext, this)
+                : null;
+
         reactContext.addActivityEventListener(mActivityEventListener);
         Log.d(LOG_TAG, "BleManager created");
     }
@@ -213,6 +224,21 @@ class BleManager extends ReactContextBaseJavaModule {
 
         if (scanManager != null)
             scanManager.scan(serviceUUIDs, scanSeconds, options, callback);
+    }
+
+    @SuppressLint("NewApi") // NOTE: constructor checks the API version.
+    @ReactMethod
+    public void companionScan(ReadableArray serviceUUIDs,  ReadableMap options, Callback callback) {
+        if (this.companionScanner == null) {
+            callback.invoke("not supported");
+        } else {
+            this.companionScanner.scan(serviceUUIDs, options, callback);
+        }
+    }
+
+    @ReactMethod
+    public void supportsCompanion(Callback callback) {
+        callback.invoke(companionScanner != null);
     }
 
     @ReactMethod
@@ -484,7 +510,7 @@ class BleManager extends ReactContextBaseJavaModule {
             callback.invoke("Peripheral not found", null);
     }
 
-    private Peripheral savePeripheral(BluetoothDevice device) {
+    public Peripheral savePeripheral(BluetoothDevice device) {
         String address = device.getAddress();
         synchronized (peripherals) {
             if (!peripherals.containsKey(address)) {
@@ -777,6 +803,48 @@ class BleManager extends ReactContextBaseJavaModule {
         } else {
             callback.invoke("Peripheral not found", null);
         }
+    }
+
+    @ReactMethod
+    public void getAssociatedPeripherals(Callback callback) {
+        Log.d(LOG_TAG, "Get associated peripherals");
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            callback.invoke("Not supported");
+            return;
+        }
+
+        WritableArray peripherals = Arguments.createArray();
+        for (String address : getCompanionDeviceManager().getAssociations()) {
+            peripherals.pushMap(retrieveOrCreatePeripheral(address).asWritableMap());
+        }
+
+        callback.invoke(null, peripherals);
+    }
+
+    @ReactMethod
+    public void removeAssociatedPeripheral(String address, Callback callback) {
+        Log.d(LOG_TAG, "Remove associated peripheral: " + address);
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            callback.invoke("Not supported");
+            return;
+        }
+
+        CompanionDeviceManager manager = getCompanionDeviceManager();
+        for (String association : manager.getAssociations()) {
+            if (association.equals(address)) {
+                manager.disassociate(address);
+                callback.invoke(null);
+                break;
+            }
+        }
+
+        callback.invoke("device not found");
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public CompanionDeviceManager getCompanionDeviceManager() {
+        return (CompanionDeviceManager) reactContext
+                .getCurrentActivity().getSystemService(Context.COMPANION_DEVICE_SERVICE);
     }
 
     private final static char[] hexArray = "0123456789ABCDEF".toCharArray();

--- a/android/src/main/java/it/innove/CompanionScanner.java
+++ b/android/src/main/java/it/innove/CompanionScanner.java
@@ -1,0 +1,118 @@
+package it.innove;
+
+import static android.app.Activity.RESULT_OK;
+
+import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
+
+import android.app.Activity;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanResult;
+import android.companion.AssociationRequest;
+import android.companion.BluetoothLeDeviceFilter;
+import android.companion.CompanionDeviceManager;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.os.Build;
+import android.os.ParcelUuid;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class CompanionScanner {
+
+    private final BleManager bleManager;
+    private final ReactContext reactContext;
+    public static final String LOG_TAG = "CompationScanManager";
+    private static final int SELECT_DEVICE_REQUEST_CODE = 540;
+
+    private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
+        @Override
+        public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
+            Log.d(LOG_TAG, "onActivityResult");
+            if (requestCode != SELECT_DEVICE_REQUEST_CODE) {
+                super.onActivityResult(activity, requestCode, resultCode, intent);
+                return;
+            }
+            if (resultCode == RESULT_OK) {
+                // Have device?
+                Log.d(LOG_TAG, "Ok activity result");
+
+                ScanResult result = intent.getParcelableExtra(CompanionDeviceManager.EXTRA_DEVICE);
+                Peripheral peripheral = bleManager.savePeripheral(result.getDevice());
+
+                bleManager.sendEvent("BleManagerCompanionPeripheral", peripheral.asWritableMap());
+            } else {
+                // No device, user cancelled?
+                Log.d(LOG_TAG, "Non-ok activity result");
+                bleManager.sendEvent("BleManagerCompanionPeripheral", null);
+            }
+        }
+    };
+
+    public CompanionScanner(ReactApplicationContext reactContext, BleManager bleManager) {
+        this.reactContext = reactContext;
+        this.bleManager = bleManager;
+        reactContext.addActivityEventListener(mActivityEventListener);
+    }
+
+    public void scan(ReadableArray serviceUUIDs, ReadableMap options, Callback callback) {
+        Log.d(LOG_TAG, "companion scan start");
+
+        AssociationRequest.Builder builder = new AssociationRequest.Builder()
+                .setSingleDevice(options.hasKey("single") && options.getBoolean("single")) ;
+
+        for (int i = 0; i < serviceUUIDs.size(); i++) {
+            final ParcelUuid uuid = new ParcelUuid(UUIDHelper.uuidFromString(serviceUUIDs.getString(i)));
+            Log.d(LOG_TAG, "Filter service: " + uuid);
+
+            builder = builder
+                    // Add LE filter.
+                    .addDeviceFilter(new BluetoothLeDeviceFilter.Builder()
+                            .setScanFilter(new ScanFilter.Builder().setServiceUuid(uuid).build())
+                            .build());
+        }
+
+        AssociationRequest pairingRequest = builder.build();
+
+        bleManager.getCompanionDeviceManager().associate(pairingRequest, new CompanionDeviceManager.Callback() {
+            @Override
+            public void onFailure(@Nullable CharSequence charSequence) {
+                Log.d(LOG_TAG, "companion failure: " + charSequence);
+                WritableMap map = Arguments.createMap();
+                map.putString("error", charSequence.toString());
+                bleManager.sendEvent("BleManagerCompanionFailure", map);
+            }
+
+            @Override
+            public void onDeviceFound(@NonNull IntentSender intentSender) {
+                Log.d(LOG_TAG, "companion device found");
+                try {
+                    reactContext.getCurrentActivity().startIntentSenderForResult(
+                            intentSender, SELECT_DEVICE_REQUEST_CODE, null, 0, 0, 0
+                    );
+                } catch (IntentSender.SendIntentException e) {
+                    Log.e(LOG_TAG, "Failed to send intent: " + e.toString());
+                    String msg = "Failed to send intent: " + e.toString();
+                    WritableMap map = Arguments.createMap();
+                    map.putString("error", msg);
+                    bleManager.sendEvent("BleManagerCompanionFailure", map);
+                }
+            }
+        }, null);
+
+        callback.invoke();
+    }
+}

--- a/docs/events.markdown
+++ b/docs/events.markdown
@@ -172,3 +172,18 @@ The peripheral received a request to start or stop providing notifications for a
 - `isNotifying` - `Boolean` - Is the characteristic notifying or not
 - `domain` - `String` - [iOS only] error domain
 - `code` - `Number` - [iOS only] error code
+
+---
+
+## BleManagerCompanionPeripheral [Android only]
+
+Associate callback received a failure or failed to start the intent to
+pick the device to associate.
+
+---
+
+## BleManagerCompanionFailure [Android only]
+
+User picked a device to associate with.
+
+Null if the request was cancelled by the user.

--- a/docs/methods.markdown
+++ b/docs/methods.markdown
@@ -83,6 +83,53 @@ BleManager.stopScan().then(() => {
 
 ---
 
+## companionScan() [Android only, API 26+]
+
+Scan for companion devices.
+
+If companion device manger is not supported on this (android) device,
+rejects. Otherwise resolves once the scan has started.
+
+There is no way to "stop" companion scanning. Once its started, it will
+eventually emit `BleManagerCompanionPeripheral` event with either:
+ 1. peripheral if user selects one
+ 2. null if user "cancels" (i.e. doesn't select anything)
+
+Emits `BleManagerCompanionPeripheralFailure` on failure.
+
+Unlike with `BleManager.scan()`, timeouts must be handled manually.
+
+See `BleManagerCompanionPeripheral` and `BleManagerCompanionPeripheralFailure` events.
+
+See `BleManager.supportsCompanion`.
+
+See: https://developer.android.com/develop/connectivity/bluetooth/companion-device-pairing
+
+**Arguments**
+
+- `serviceUUIDs` - `String[]` - List of service UUIDs to use as a filter
+- `options` - `JSON` -  Additional options
+
+  - `single` - `String?` - Scan only for single peripheral. See Android's `AssocationRequest.Builder.setSingleDevice`.
+
+**Examples**
+
+```js
+const emitter = new NativeEventEmitter(NativeModules.BleManager);
+
+emitter.addListener('BleManagerCompanionPeripheral', peripheral => {
+  if (peripheral === null) {
+    // User didn't select any peripheral.
+  } else {
+    // User selected a peripheral.
+  }
+});
+
+BleManager.compationScan();
+```
+
+---
+
 ## connect(peripheralId, options)
 
 Attempts to connect to a peripheral. In many case if you can't connect you have to scan for the peripheral before.
@@ -179,6 +226,12 @@ BleManager.checkState().then((state) =>
   console.log(`current BLE state = '${state}'.`)
 );
 ```
+
+---
+
+## supportsCompanion() [Android only]
+
+Check if current device supports companion device manager.
 
 ---
 
@@ -614,6 +667,24 @@ BleManager.getConnectedPeripherals([]).then((peripheralsArray) => {
   console.log("Connected peripherals: " + peripheralsArray.length);
 });
 ```
+
+---
+
+## getAssociatedPeripherals() [Android only, API 26+]
+
+Retrive associated peripherals (from companion manager).
+
+---
+
+## removeAssociatedPeripheral(peripheralId) [Android only, API 26+]
+
+Remove a associated peripheral.
+
+Rejects if no association is found.
+
+**Arguments**
+
+- `peripheralId` - `String` - Peripheral to remove
 
 ---
 

--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -140,5 +140,15 @@ RCT_EXTERN_METHOD(refreshCache:(NSString *)peripheralUUID
 RCT_EXTERN_METHOD(setName:(NSString *)name
                   callback:(nonnull RCTResponseSenderBlock)callback)
 
+RCT_EXTERN_METHOD(getAssociatedPeripherals:(nonnull RCTResponseSenderBlock)callback)
+
+RCT_EXTERN_METHOD(removeAssociatedPeripheral:(NSString *)peripheralUUID
+                  callback:(nonnull RCTResponseSenderBlock)callback)
+
+RCT_EXTERN_METHOD(supportsCompanion:(nonnull RCTResponseSenderBlock)callback)
+
+RCT_EXTERN_METHOD(companionScan:
+                  (NSArray *)serviceUUIDs
+                  callback:(nonnull RCTResponseSenderBlock)callback)
 
 @end

--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -553,7 +553,7 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
                      maxByteSize: Int,
                      callback: @escaping RCTResponseSenderBlock) {
         NSLog("write")
-                
+        
         guard let context = getContext(peripheralUUID, serviceUUIDString: serviceUUID, characteristicUUIDString: characteristicUUID, prop: CBCharacteristicProperties.write, callback: callback) else {
             return
         }
@@ -1239,6 +1239,24 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
     
     @objc func setName(_ name: String,
                        callback: @escaping RCTResponseSenderBlock) {
+        callback(["Not supported"])
+    }
+    
+    @objc func getAssociatedPeripherals(_ callback: @escaping RCTResponseSenderBlock) {
+        callback(["Not supported"])
+    }
+    
+    @objc func removeAssociatedPeripheral(_ peripheralUUID: String,
+                                          callback: @escaping RCTResponseSenderBlock) {
+        callback(["Not supported"])
+    }
+    
+    @objc func supportsCompanion(_ callback: @escaping RCTResponseSenderBlock) {
+        callback(["Not supported"])
+    }
+    
+    @objc public func companionScan(_ serviceUUIDs: [Any],
+                                    callback:RCTResponseSenderBlock) {
         callback(["Not supported"])
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -718,8 +718,6 @@ class BleManager extends NativeEventEmitter {
    *
    * Check if current device supports companion device manager.
    *
-   * If not, companionScan will always reject.
-   *
    * @return Promise resolving to a boolean.
    */
   supportsCompanion() {
@@ -731,25 +729,7 @@ class BleManager extends NativeEventEmitter {
   /**
    * [Android only, API 26+]
    *
-   * Scan for companion devices.
-   *
-   * If companion device manger is not supported on this (android) device,
-   * rejects. Otherwise resolves once the scan has started.
-   *
-   * There is no way to "stop" companion scanning. Once its started, it will
-   * eventually emit `BleManagerCompanionPeripheral` event with either:
-   *   1. peripheral if user selects one
-   *   2. null if user "cancels" (i.e. doesn't select anything)
-   *
-   * Emits `BleManagerCompanionPeripheralFailure` on failure.
-   *
-   * Unlike with `BleManager.scan()`, timeouts must be handled manually.
-   *
-   * See `BleManagerCompanionPeripheral` and `BleManagerCompanionPeripheralFailure` events.
-   *
-   * See `BleManager.supportsCompanion`.
-   *
-   * See: https://developer.android.com/develop/connectivity/bluetooth/companion-device-pairing
+   * Start companion scan.
    */
   companionScan(
     serviceUUIDs: string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   BleState,
   ConnectOptions,
   ConnectionPriority,
+  CompanionScanOptions,
   Peripheral,
   PeripheralInfo,
   ScanOptions,
@@ -674,6 +675,94 @@ class BleManager extends NativeEventEmitter {
           }
         }
       );
+    });
+  }
+
+  /**
+   * [Android only, API 26+]
+   *
+   * @returns
+   */
+  getAssociatedPeripherals() {
+    return new Promise<Peripheral[]>((fulfill, reject) => {
+      bleManager.getAssociatedPeripherals((error: string | null, peripherals: Peripheral[] | null) => {
+        if (error) {
+          reject(error);
+        } else {
+          fulfill(peripherals || []);
+        }
+      });
+    });
+  }
+
+  /**
+   * [Android only, API 26+]
+   * @param peripheralId Peripheral to remove
+   * @returns Promise that resolves once the peripheral has been removed. Rejects
+   *          if no association is found.
+   */
+  removeAssociatedPeripheral(peripheralId: string) {
+    return new Promise<void>((fulfill, reject) => {
+      bleManager.removeAssociatedPeripheral(peripheralId, (error: string | null) => {
+        if (error !== null) {
+          reject(error);
+        } else {
+          fulfill();
+        }
+      });
+    });
+  }
+
+  /**
+   * [Android only]
+   *
+   * Check if current device supports companion device manager.
+   *
+   * If not, companionScan will always reject.
+   *
+   * @return Promise resolving to a boolean.
+   */
+  supportsCompanion() {
+    return new Promise<boolean>(fulfill => {
+      bleManager.supportsCompanion((supports: boolean) => fulfill(supports));
+    });
+  }
+
+  /**
+   * [Android only, API 26+]
+   *
+   * Scan for companion devices.
+   *
+   * If companion device manger is not supported on this (android) device,
+   * rejects. Otherwise resolves once the scan has started.
+   *
+   * There is no way to "stop" companion scanning. Once its started, it will
+   * eventually emit `BleManagerCompanionPeripheral` event with either:
+   *   1. peripheral if user selects one
+   *   2. null if user "cancels" (i.e. doesn't select anything)
+   *
+   * Emits `BleManagerCompanionPeripheralFailure` on failure.
+   *
+   * Unlike with `BleManager.scan()`, timeouts must be handled manually.
+   *
+   * See `BleManagerCompanionPeripheral` and `BleManagerCompanionPeripheralFailure` events.
+   *
+   * See `BleManager.supportsCompanion`.
+   *
+   * See: https://developer.android.com/develop/connectivity/bluetooth/companion-device-pairing
+   */
+  companionScan(
+    serviceUUIDs: string[],
+    options: CompanionScanOptions = {}
+  ) {
+    return new Promise<void>((fulfill, reject) => {
+      bleManager.companionScan(serviceUUIDs, options, (error: string | null) => {
+        if (error) {
+          reject(error)
+        } else {
+          fulfill();
+        }
+      });
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,21 @@ export interface ScanOptions {
    * if `callbackType` is set to `FirstMatch`, the shortenedLocalName will be used for filtering.
    * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
    */
-  exactAdvertisingName?: string|string[];
+  exactAdvertisingName?: string | string[];
+  /**
+   * When using compaion mode, only associate single peripheral.
+   *
+   * See: https://developer.android.com/reference/android/companion/AssociationRequest.Builder#setSingleDevice(boolean)
+   */
+  single?: boolean;
+  companion?: boolean;
+}
+
+export interface CompanionScanOptions {
+  /**
+   * Scan only for a single peripheral.
+   */
+  single?: boolean;
 }
 
 /**
@@ -345,3 +359,20 @@ export interface BleManagerDidUpdateNotificationStateForEvent {
    */
   readonly code: number;
 }
+
+/**
+ * [Android only]
+ *
+ * Associate callback received a failure or failed to start the intent to
+ * pick the device to associate.
+ */
+export type BleManagerCompanionFailure = { error: string; };
+
+/**
+ * [Android only]
+ *
+ * User picked a device to associate with.
+ *
+ * Null if the request was cancelled by the user.
+ */
+export type BleManagerCompanionPeripheral = Peripheral | null;


### PR DESCRIPTION
Android's `CompanionDeviceManager` is used to get access[1,2] (association) to a Bluetooth LE (and classic Bluetooth) devices without requiring too broad permission set (notably location on older android versions).

Using `CompanionDeviceManager` is also a requirement for implementing background connection management, tho' it also requires the application to implement `CompationDeviceService`[3].

`CompationDeviceManager` availability is not guaranteed, hence the few API version and feature detection checks.

iOS stubs are missing at the moment.

1: https://developer.android.com/develop/connectivity/bluetooth/companion-device-pairing
2: https://developer.android.com/reference/android/companion/CompanionDeviceManager
3: https://developer.android.com/reference/android/companion/CompanionDeviceService

Assuming this feature is welcome, TODO before ready:

- [x] iOS stubs
- [ ] Check the error handling (at least the `onDeviceFound` exception handling gives perhaps too long error message)
- [x] docs