### PR TITLE
Fix recursive loops causing StackOverflowError on Android 13+

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -419,8 +419,10 @@ public class Peripheral extends BluetoothGattCallback {
 
     @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
-        super.onCharacteristicChanged(gatt, characteristic);
-        onCharacteristicChanged(gatt, characteristic, characteristic.getValue());
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            super.onCharacteristicChanged(gatt, characteristic);
+            onCharacteristicChanged(gatt, characteristic, characteristic.getValue());
+        }
     }
 
     @Override
@@ -468,8 +470,10 @@ public class Peripheral extends BluetoothGattCallback {
 
     @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-        super.onCharacteristicRead(gatt, characteristic, status);
-        onCharacteristicRead(gatt, characteristic, characteristic.getValue(), status);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            super.onCharacteristicRead(gatt, characteristic, status);
+            onCharacteristicRead(gatt, characteristic, characteristic.getValue(), status);
+        }
     }
     @Override
     public void onCharacteristicRead(@NonNull final BluetoothGatt gatt,


### PR DESCRIPTION
[59c37a3](https://github.com/innoveit/react-native-ble-manager/commit/59c37a3084769ea6b7333df30f279ff6bfbde314) inadvertently introduced two recursive loops in the onCharacteristicChanged & onCharacteristicRead methods, affecting devices running Android 13+ (see #1128).

We addressed the problem by adding a conditional check to limit the execution of the overlapping method to Android 12 (API level 31) and below.