### PR TITLE
ios: correctly insert callbacks

### DIFF
--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -111,14 +111,9 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
     // Helper method to insert callback in different queues
     func insertCallback(_ callback: @escaping RCTResponseSenderBlock, intoDictionary dictionary: inout Dictionary<String, [RCTResponseSenderBlock]>, withKey key: String) {
         serialQueue.sync {
-            if var peripheralCallbacks = dictionary[key] {
-                peripheralCallbacks.append(callback)
-            } else {
-                var peripheralCallbacks = [RCTResponseSenderBlock]()
-                peripheralCallbacks.append(callback)
-                dictionary[key] = peripheralCallbacks
-            }
-            
+            var peripheralCallbacks = dictionary[key] ?? [RCTResponseSenderBlock]()
+            peripheralCallbacks.append(callback)
+            dictionary[key] = peripheralCallbacks
         }
     }
     


### PR DESCRIPTION
The `if var ... = dict[key]` syntax doesn't return a reference, but a copy which must then be inserted back to the dictionary.