### PR TITLE
[Android] Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+	def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+	if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+	  namespace "it.innove"
+	}
+	
 	compileSdk safeExtGet("compileSdk", 33)
 
 	compileOptions {


### PR DESCRIPTION
Gradle 8.0.2 - Update build.gradle w/ Namespace

FAILURE: Build failed with an exception.

```
* What went wrong:
A problem occurred configuring project ':react-native-ble-manager'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }
```

![image](https://github.com/innoveit/react-native-ble-manager/assets/37247941/3a81234b-b7a6-482b-a7d2-824dfa22f685)

