### PR TITLE
Fixed podspec to require iOS 10 instead of iOS 9, to prevent build errors on iOS

### DIFF
--- a/react-native-ble-manager.podspec
+++ b/react-native-ble-manager.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.authors		= { "Innove" => "https://github.com/innoveit" }
   s.homepage    	= "https://github.com/innoveit/react-native-ble-manager"
   s.license     	= "Apache-2.0"
-  s.platform    	= :ios, "9.0"
+  s.platform    	= :ios, "10.0"
   s.source      	= { :git => "https://github.com/innoveit/react-native-ble-manager.git" }
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift}"
 


### PR DESCRIPTION
We were running into build errors when trying to use this library, specifically that `CBManagerState` is not available below iOS 10. We ourselves have everything pinned to iOS 13, and the only source of iOS < 10 we could find was this library.

Updating the podspec to reflect the requirement did the trick, so I hope this can be useful to other people as well.

Thanks for considering and thanks for a great library!