### PR TITLE
Fixed incorrect signature for isScanning: on iOS

### DIFF
--- a/ios/BleManager.m
+++ b/ios/BleManager.m
@@ -98,8 +98,7 @@ RCT_EXTERN_METHOD(isPeripheralConnected:
                   (NSString *)peripheralUUID
                   callback:(nonnull RCTResponseSenderBlock)callback)
 
-RCT_EXTERN_METHOD(isScanning:
-                  callback:(nonnull RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(isScanning:(nonnull RCTResponseSenderBlock)callback)
 
 RCT_EXTERN_METHOD(getMaximumWriteValueLengthForWithoutResponse:
                   (NSString *)peripheralUUID


### PR DESCRIPTION
The signature of `isScanning` is incorrect in the iOS native code RTC definitions, leading to a runtime exception when calling the function:

![Untitled](https://github.com/innoveit/react-native-ble-manager/assets/95790/5a02c4cd-0c4a-46fb-a4f3-ea142fc547c7)

This PR fixes the signature, allowing the function to be called successfully on iOS again.