### PR TITLE
feature: scan filter for manufacturer data

### DIFF
--- a/android/src/main/java/it/innove/DefaultScanManager.java
+++ b/android/src/main/java/it/innove/DefaultScanManager.java
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @SuppressLint("MissingPermission")
@@ -102,6 +103,38 @@ public class DefaultScanManager extends ScanManager {
             Log.d(BleManager.LOG_TAG, "Filter on advertising names:" + expectedNames);
             for (Object name : expectedNames) {
                 ScanFilter filter = new ScanFilter.Builder().setDeviceName(name.toString()).build();
+                filters.add(filter);
+            }
+        }
+
+        if (options.hasKey("manufacturerData")) {
+            ReadableMap manufacturerDataMap = options.getMap("manufacturerData");
+            if (manufacturerDataMap != null && manufacturerDataMap.hasKey("manufacturerId")) {
+                int manufacturerId = manufacturerDataMap.getInt("manufacturerId");
+                ReadableArray manufacturerData = manufacturerDataMap.getArray("manufacturerData");
+                ReadableArray manufacturerDataMask = manufacturerDataMap.getArray("manufacturerDataMask");
+                byte[] manufacturerDataBytes = new byte[0];
+                byte[] manufacturerDataMaskBytes = new byte[0];
+                if (manufacturerData != null) {
+                    manufacturerDataBytes = new byte[manufacturerData.size()];
+                    for (int i = 0; i < manufacturerData.size(); i++) {
+                        manufacturerDataBytes[i] = Integer.valueOf(manufacturerData.getInt(i)).byteValue();
+                    }
+                }
+                if (manufacturerDataMask != null) {
+                    manufacturerDataMaskBytes = new byte[manufacturerDataMask.size()];
+                    for (int i = 0; i < manufacturerDataMask.size(); i++) {
+                        manufacturerDataMaskBytes[i] = Integer.valueOf(manufacturerDataMask.getInt(i)).byteValue();
+                    }
+                }
+                if (manufacturerDataBytes.length != manufacturerDataMaskBytes.length) {
+                    callback.invoke("manufacturerData and manufacturerDataMask must have the same length");
+                    return;
+                }
+                Log.d(BleManager.LOG_TAG, "Filter on manufacturerId: " + manufacturerId);
+                Log.d(BleManager.LOG_TAG, "Filter on manufacturerData: " + Arrays.toString(manufacturerDataBytes));
+                Log.d(BleManager.LOG_TAG, "Filter on manufacturerDataMask: " + Arrays.toString(manufacturerDataMaskBytes));
+                ScanFilter filter = new ScanFilter.Builder().setManufacturerData(manufacturerId, manufacturerDataBytes, manufacturerDataMaskBytes).build();
                 filters.add(filter);
             }
         }

--- a/android/src/main/java/it/innove/DefaultScanManager.java
+++ b/android/src/main/java/it/innove/DefaultScanManager.java
@@ -131,10 +131,21 @@ public class DefaultScanManager extends ScanManager {
                     callback.invoke("manufacturerData and manufacturerDataMask must have the same length");
                     return;
                 }
-                Log.d(BleManager.LOG_TAG, "Filter on manufacturerId: " + manufacturerId);
-                Log.d(BleManager.LOG_TAG, "Filter on manufacturerData: " + Arrays.toString(manufacturerDataBytes));
-                Log.d(BleManager.LOG_TAG, "Filter on manufacturerDataMask: " + Arrays.toString(manufacturerDataMaskBytes));
-                ScanFilter filter = new ScanFilter.Builder().setManufacturerData(manufacturerId, manufacturerDataBytes, manufacturerDataMaskBytes).build();
+                Log.d(
+                    BleManager.LOG_TAG,
+                    String.format(
+                        "Filter on manufacturerId: %d; manufacturerData: %s; manufacturerDataMask: %s",
+                        manufacturerId,
+                        Arrays.toString(manufacturerDataBytes),
+                        Arrays.toString(manufacturerDataMaskBytes)
+                    )
+                );
+                ScanFilter filter = new ScanFilter.Builder()
+                    .setManufacturerData(
+                        manufacturerId,
+                        manufacturerDataBytes,
+                        manufacturerDataMaskBytes
+                    ).build();
                 filters.add(filter);
             }
         }

--- a/docs/methods.markdown
+++ b/docs/methods.markdown
@@ -55,6 +55,11 @@ Returns a `Promise` object.
   - `phy` - `Number` - [Android only] corresponding to [`setPhy`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setPhy(int)>)
   - `legacy` - `Boolean` - [Android only] corresponding to [`setLegacy`](<https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)>)
   - `exactAdvertisingName` - `string[]` - In Android corresponds to the `ScanFilter` [deviceName](<https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)>). In iOS the filter is done manually before sending the peripheral.
+  - `manufacturerData` - `object` - [Android only] corresponding to [`setManufacturerData`](<https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setManufacturerData(int,%20byte[],%20byte[])>). Filter by manufacturer id or data.
+    - `manufacturerId` - `number` - Manufacturer / company id to filter for.
+    - `manufacturerData` - `number[]` - Additional manufacturer data filter.
+    - `manufacturerDataMask` - `number[]` - Mask for manufacturer data, must have the same length as `manufacturerData`.
+      For any bit in the mask, set it to 1 if it needs to match the one in manufacturer data, otherwise set it to 0.
 
 **Examples**
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,18 @@ export interface ScanOptions {
    * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
    */
   exactAdvertisingName?: string|string[];
+  /**
+   * Android only. Filters scan results by manufacturer id and data.
+   * `manufacturerId` usually matches the company id, can be given as a hex, e.g. 0xe4f7.
+   * `manufacturerData` and `manufacturerDataMask` must have the same length. For any bit in the mask, set it to 1 if
+   * it needs to match the one in manufacturer data, otherwise set it to 0.
+   * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setManufacturerData(int,%20byte[],%20byte[])
+   */
+  manufacturerData?: {
+    manufacturerId: number;
+    manufacturerData?: number[];
+    manufacturerDataMask?: number[];
+  }
 }
 
 /**


### PR DESCRIPTION
Currently it is not possible to filter by manufacturer id or data during scan on android. This PR adds an optional scan option to filter for peripherals using androids `ScanFilter.Builder.setManufacturerData`.
Not sure whether something similar is possible on iOS, so currently it only works on android.

This shouldn't be a breaking change.

Example usage:
```ts
await BleManager.scan([], 5, false, {
  manufacturerData: {
    manufacturerId: 0xe4f7,
    manufacturerData: [12,3,7],
    manufacturerDataMask: [0,0,1]
  },
});
```