### PR TITLE
Update BleManager.swift

### DIFF
--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -318,9 +318,9 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
             if let uuid = UUID(uuidString: peripheralUUID) {
                 let peripheralArray = manager?.retrievePeripherals(withIdentifiers: [uuid])
                 if let retrievedPeripheral = peripheralArray?.first {
-                    objc_sync_enter(peripherals)
-                    peripherals[retrievedPeripheral.uuidAsString()] = Peripheral(peripheral:retrievedPeripheral)
-                    objc_sync_exit(peripherals)
+                    serialQueue.sync {
+                        peripherals[retrievedPeripheral.uuidAsString()] = Peripheral(peripheral:retrievedPeripheral)
+                    }
                     NSLog("Successfully retrieved and connecting to peripheral with UUID: \(peripheralUUID)")
                     
                     // Connect to the retrieved peripheral


### PR DESCRIPTION
If you are reading getDiscoveredPeripherals while trying to connect to a device the thread will lock up and crash the app. Instead of "objc_sync_enter" we should use serialQueue.sync so its queued. From the research i did i believe "objc_sync_enter" should be avoided if possible. 