### PR TITLE
Fix crash during doWrite error handling

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -1069,7 +1069,7 @@ public class Peripheral extends BluetoothGattCallback {
                 if (!gatt.writeCharacteristic(characteristic)) {
                     // write without response, caller will handle the callback
                     for (Callback writeCallback : writeCallbacks) {
-                        writeCallback.invoke("Write failed", writeCallback);
+                        writeCallback.invoke("Write failed", null);
                     }
                     writeCallbacks.clear();
                     completedCommand();


### PR DESCRIPTION
The write callback should not be passed into the callback. Instead there should be no result since an error is already passed.
Relevant ADB logs:
```
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: java.lang.RuntimeException: Cannot convert argument of type class com.facebook.react.bridge.CallbackImpl
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at com.facebook.react.bridge.Arguments.fromJavaArgs(Arguments.java:187)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at com.facebook.react.bridge.CallbackImpl.invoke(CallbackImpl.java:31)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at it.innove.Peripheral$3.run(Peripheral.java:1078)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at it.innove.Peripheral$2.run(Peripheral.java:956)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at android.os.Handler.handleCallback(Handler.java:958)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at android.os.Handler.dispatchMessage(Handler.java:99)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at android.os.Looper.loopOnce(Looper.java:230)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at android.os.Looper.loop(Looper.java:319)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at android.app.ActivityThread.main(ActivityThread.java:8893)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at java.lang.reflect.Method.invoke(Native Method)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
02-21 13:25:13.231 31032 31032 E ReactNativeBleManager: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```