### PR TITLE
adjusted retrieveServices response for ios

### DIFF
--- a/ios/Helper.swift
+++ b/ios/Helper.swift
@@ -268,7 +268,7 @@ class Peripheral:Hashable {
     }
     
     func servicesInfo() -> Dictionary<String, Any> {
-        var servicesInfo: [String: Any] = [:]
+        var servicesInfo: [String: Any] = advertisingInfo()
         
         var serviceList = [[String: Any]]()
         var characteristicList = [[String: Any]]()


### PR DESCRIPTION
According to [types.ts](https://github.com/innoveit/react-native-ble-manager/tree/master/src/types.ts) file, retrieveServices command should include 
```
  id: string;
  rssi: number;
  name?: string;
  advertising: AdvertisingData; 
```
as response. For Android it works as described, but ios since swift migration returns only characteristics and services. This small fix brings back missing data to the response.