### PR TITLE
Add support for Android 14 (Fix crash issue on Android 14)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
 	  namespace "it.innove"
 	}
 	
-	compileSdk safeExtGet("compileSdk", 33)
+	compileSdk safeExtGet("compileSdk", 34)
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_9
@@ -34,7 +34,7 @@ android {
 
 	defaultConfig {
 		minSdkVersion safeExtGet("minSdkVersion", 21)
-		targetSdk safeExtGet("targetSdk", 33)
+		targetSdk safeExtGet("targetSdk", 34)
 	}
 	lintOptions {
 		abortOnError false

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -155,7 +155,7 @@ class BleManager extends ReactContextBaseJavaModule {
         filter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
         IntentFilter intentFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
         intentFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY);
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE){
             // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 32(UPSIDE_DOWN_CAKE) on registering receivers.
             // Also the export flags are available on Android 8 and higher, should be used with caution so that don't break compability with that devices.
             context.registerReceiver(mReceiver, filter, Context.RECEIVER_NOT_EXPORTED);

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -153,10 +153,18 @@ class BleManager extends ReactContextBaseJavaModule {
 
         IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
         filter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-        context.registerReceiver(mReceiver, filter);
         IntentFilter intentFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
         intentFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY);
-        context.registerReceiver(mReceiver, intentFilter);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE){
+            // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 32(UPSIDE_DOWN_CAKE) on registering receivers.
+            // Also the export flags are available on Android 8 and higher, should be used with caution so that don't break compability with that devices.
+            context.registerReceiver(mReceiver, filter, context.RECEIVER_NOT_EXPORTED);
+            context.registerReceiver(mReceiver, intentFilter, context.RECEIVER_NOT_EXPORTED);        
+        }else {
+            context.registerReceiver(mReceiver, filter);
+            context.registerReceiver(mReceiver, intentFilter);
+        }
+        
         callback.invoke();
         Log.d(LOG_TAG, "BleManager initialized");
     }

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -158,8 +158,8 @@ class BleManager extends ReactContextBaseJavaModule {
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE){
             // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 32(UPSIDE_DOWN_CAKE) on registering receivers.
             // Also the export flags are available on Android 8 and higher, should be used with caution so that don't break compability with that devices.
-            context.registerReceiver(mReceiver, filter, context.RECEIVER_NOT_EXPORTED);
-            context.registerReceiver(mReceiver, intentFilter, context.RECEIVER_NOT_EXPORTED);        
+            context.registerReceiver(mReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+            context.registerReceiver(mReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);        
         }else {
             context.registerReceiver(mReceiver, filter);
             context.registerReceiver(mReceiver, intentFilter);

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -3,6 +3,7 @@ package it.innove;
 import static android.app.Activity.RESULT_OK;
 import static android.bluetooth.BluetoothProfile.GATT;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -155,16 +156,16 @@ class BleManager extends ReactContextBaseJavaModule {
         filter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
         IntentFilter intentFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
         intentFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE){
-            // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 32(UPSIDE_DOWN_CAKE) on registering receivers.
+        if (Build.VERSION.SDK_INT >= UPSIDE_DOWN_CAKE){
+            // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 34(UPSIDE_DOWN_CAKE) on registering receivers.
             // Also the export flags are available on Android 8 and higher, should be used with caution so that don't break compability with that devices.
             context.registerReceiver(mReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
-            context.registerReceiver(mReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);        
-        }else {
+            context.registerReceiver(mReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
             context.registerReceiver(mReceiver, filter);
             context.registerReceiver(mReceiver, intentFilter);
         }
-        
+
         callback.invoke();
         Log.d(LOG_TAG, "BleManager initialized");
     }
@@ -189,9 +190,9 @@ class BleManager extends ReactContextBaseJavaModule {
                     }catch(Exception e){
                         callback.invoke("Current activity not available");
                     }
-                    
+
                 }
-                
+
         } else
             callback.invoke();
     }


### PR DESCRIPTION
Since android 13 **were added** two flags when registering receivers: **RECEIVER_EXPORTED** and **RECEIVER_NOT_EXPORTED**. 
Those flags explicitly tells  whether the intention filters are for in-app or for other apps intents too.
I guess RECEIVER_NOT_EXPORTED is the best suitable since we don't want other apps messing up with our intents.
When that flag is not set Android always crashes the app with a exception.

Tested on Android 14.

Solves the #1186.

Android registerReceiver full description: https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter,%20int)