### PR TITLE
Remove the need for manually changing targetSdk to 34.

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -3,7 +3,6 @@ package it.innove;
 import static android.app.Activity.RESULT_OK;
 import static android.bluetooth.BluetoothProfile.GATT;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
@@ -167,7 +166,7 @@ class BleManager extends ReactContextBaseJavaModule {
         filter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
         IntentFilter intentFilter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
         intentFilter.setPriority(IntentFilter.SYSTEM_HIGH_PRIORITY);
-        if (Build.VERSION.SDK_INT >= UPSIDE_DOWN_CAKE){
+        if (Build.VERSION.SDK_INT >= 34){ // Android 14, UPSIDE_DOWN_CAKE
             // Google in 2023 decides that flag RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED should be explicit set SDK 34(UPSIDE_DOWN_CAKE) on registering receivers.
             // Also the export flags are available on Android 8 and higher, should be used with caution so that don't break compability with that devices.
             context.registerReceiver(mReceiver, filter, Context.RECEIVER_EXPORTED);


### PR DESCRIPTION
Since the latest changes into _BleManager.java_ some users had to manually bump the _targetSdk_ version into the application. 
This small change is for better compatibility into existing projects and newer users as the _targetSdk_ for new react-native project is 33.
