### PR TITLE
Fix ios native crash caused by concurrent dictionary access

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -38,8 +38,7 @@
       }
     },
     "..": {
-      "name": "react-native-ble-manager",
-      "version": "11.5.0",
+      "version": "11.5.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "react-native": "0.73.6",

--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -122,14 +122,17 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
     // Helper method to call the callbacks for a specific peripheral and clear the queue
     func invokeAndClearDictionary(_ dictionary: inout Dictionary<String, [RCTResponseSenderBlock]>, withKey key: String, usingParameters parameters: [Any]) {
         serialQueue.sync {
-            
-            if let peripheralCallbacks = dictionary[key] {
-                for callback in peripheralCallbacks {
-                    callback(parameters)
-                }
-                
-                dictionary.removeValue(forKey: key)
+            invokeAndClearDictionary_THREAD_UNSAFE(&dictionary, withKey: key, usingParameters: parameters)
+        }
+    }
+
+    func invokeAndClearDictionary_THREAD_UNSAFE(_ dictionary: inout Dictionary<String, [RCTResponseSenderBlock]>, withKey key: String, usingParameters parameters: [Any]) {
+        if let peripheralCallbacks = dictionary[key] {
+            for callback in peripheralCallbacks {
+                callback(parameters)
             }
+            
+            dictionary.removeValue(forKey: key)
         }
     }
     
@@ -1078,16 +1081,18 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
             NSLog("Read value [\(characteristic.uuid)]: \( value.hexadecimalString())")
         }
         
-        if readCallbacks[key] != nil {
-            invokeAndClearDictionary(&readCallbacks, withKey: key, usingParameters: [NSNull(), characteristic.value!.toArray()])
-        } else {
-            if hasListeners {
-                sendEvent(withName: "BleManagerDidUpdateValueForCharacteristic", body: [
-                    "peripheral": peripheral.uuidAsString(),
-                    "characteristic": characteristic.uuid.uuidString.lowercased(),
-                    "service": characteristic.service!.uuid.uuidString.lowercased(),
-                    "value": characteristic.value!.toArray()
-                ])
+        serialQueue.sync {
+            if readCallbacks[key] != nil {
+                invokeAndClearDictionary_THREAD_UNSAFE(&readCallbacks, withKey: key, usingParameters: [NSNull(), characteristic.value!.toArray()])
+            } else {
+                if hasListeners {
+                    sendEvent(withName: "BleManagerDidUpdateValueForCharacteristic", body: [
+                        "peripheral": peripheral.uuidAsString(),
+                        "characteristic": characteristic.uuid.uuidString.lowercased(),
+                        "service": characteristic.service!.uuid.uuidString.lowercased(),
+                        "value": characteristic.value!.toArray()
+                    ])
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview

This fixes issue #1233.

Crash is caused by concurrent access of dictionary `readCallbacks[key]` in the if-statement condition.

1. Fixing the issue by wrapping the entire if-statement in serialQueue.sync so that concurrent calls are sequentialized.
2. Add "Read characteristics" button in example app to `console.log` all characteristics for connected peripherals

<img width="200" alt="Screenshot 2024-06-12 at 6 38 15 PM" src="https://github.com/innoveit/react-native-ble-manager/assets/2507829/a53d6356-7bcb-4678-a13c-3c0539e2f528">

## Testing

Applied the patch ([test-concurrency.patch](https://github.com/user-attachments/files/15812595/test-concurrency.patch)) to simulate multiple read events and:
* Verified ios example app crashes before fix.
* Verified ios example app does not crash after fix.