### PR TITLE
Fixing uuidAsString calls in Helper key method

### DIFF
--- a/ios/Helper.swift
+++ b/ios/Helper.swift
@@ -165,13 +165,13 @@ class Helper {
     
     static func key(forPeripheral peripheral: CBPeripheral,
                     andCharacteristic characteristic: CBCharacteristic) -> String {
-        return "\(String(describing: peripheral.uuidAsString))|\(characteristic.uuid)"
+        return "\(String(describing: peripheral.uuidAsString()))|\(characteristic.uuid)"
     }
     
     static func key(forPeripheral peripheral: CBPeripheral,
                     andCharacteristic characteristic: CBCharacteristic,
                     andDescriptor descriptor: CBDescriptor) -> String {
-        return "\(String(describing: peripheral.uuidAsString))|\(characteristic.uuid)|\(descriptor.uuid)"
+        return "\(String(describing: peripheral.uuidAsString()))|\(characteristic.uuid)|\(descriptor.uuid)"
     }
     
     static func findDescriptor(fromUUID UUID: CBUUID, characteristic: CBCharacteristic) -> CBDescriptor? {


### PR DESCRIPTION
In iOS code, We are building a unique key for a given `peripheral / characteristic / descriptor`, with using `Helper.key` method.

Here we are using `peripheral.uuidAsString` to build the final key but as this is a function and not a value, this will always return instead of the actual uuid string. and so, if we are reading BLE characteristic values for different peripherals, it will always return the same key. And eventually app will be updated with the same readcallbacks every time instead of reporting readcallbacks as per peripheral.
To get the correct string we should be calling `peripheral.uuidAsString()` and so we get a unique key built for each use-case

Understanding by printing values:
 ```
static func key(forPeripheral peripheral: CBPeripheral,
                    andCharacteristic characteristic: CBCharacteristic) -> String {
        print("uuidAsString=>%@",peripheral.uuidAsString)
        print("uuidAsString()=>%@",peripheral.uuidAsString())
        print("old1 %@","\(String(describing: peripheral.uuidAsString))|\(characteristic.uuid)")
        print("new1  %@","\(String(describing: peripheral.uuidAsString()))|\(characteristic.uuid)")
        return "\(String(describing: peripheral.uuidAsString))|\(characteristic.uuid)"
    }
```

We get logs
```
uuidAsString=>%@ (Function)
uuidAsString()=>%@ my-actual-uuid-for-this-peripheral
old1 %@ (Function)|my-actual-uuid-for-this-characteristic
new1  %@ my-actual-uuid-for-this-peripheral|my-actual-uuid-for-this-characteristic
```