### PR TITLE
[FIX] errors were ignored due to broken serialization in read()

### DIFF
--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -332,11 +332,11 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
                 } else {
                     let error = "Could not find peripheral \(peripheralUUID)."
                     NSLog(error)
-                    callback([error.localizedDescription, NSNull()])
+                    callback([error, NSNull()])
                 }
             } else {
                 let error = "Wrong UUID format \(peripheralUUID)"
-                callback([error.localizedDescription, NSNull()])
+                callback([error, NSNull()])
             }
         }
     }

--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -332,11 +332,11 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
                 } else {
                     let error = "Could not find peripheral \(peripheralUUID)."
                     NSLog(error)
-                    callback([error, NSNull()])
+                    callback([error.localizedDescription, NSNull()])
                 }
             } else {
                 let error = "Wrong UUID format \(peripheralUUID)"
-                callback([error, NSNull()])
+                callback([error.localizedDescription, NSNull()])
             }
         }
     }
@@ -1025,7 +1025,7 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
         
         if let error = error {
             NSLog("Error reading descriptor value for \(descriptor.uuid) on characteristic \(descriptor.characteristic!.uuid) :\(error)")
-            invokeAndClearDictionary(&readDescriptorCallbacks, withKey: key, usingParameters: [error, NSNull()])
+            invokeAndClearDictionary(&readDescriptorCallbacks, withKey: key, usingParameters: [error.localizedDescription, NSNull()])
             return
         }
         
@@ -1073,7 +1073,7 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
         
         if let error = error {
             NSLog("Error \(characteristic.uuid) :\(error)")
-            invokeAndClearDictionary(&readCallbacks, withKey: key, usingParameters: [error, NSNull()])
+            invokeAndClearDictionary(&readCallbacks, withKey: key, usingParameters: [error.localizedDescription, NSNull()])
             return
         }
         


### PR DESCRIPTION
That bug was a tricky one. I was wondering why I couldn't properly detect iOS errors like `Authentication is insufficient.` or `Encryption is insufficient.` which happen after "forgetting" a BLE device and then trying to read a characteristic. Even when wrapping a `try ... catch` block around a `read()` call, `read()` only returned a null buffer instead of throwing an error.

It took me a while to find the underlying problem which is an NSError occurring in [peripheral(_:didUpdateValueFor:error:)](https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/peripheral(_:didupdatevaluefor:error:)-1xyna) directly being passed as argument for `RCTResponseSenderBlock` although it is not a standard JSON type. As a result, on the Javascript-side of React Native the NSError was swallowed and came out as null, which was interpreted as no error at all with a null array.

I fixed all places where the error was directly passed and now `read()` correctly throws an error as expected in my code.

I think this also fixes at least this issue I found during debugging:
https://github.com/innoveit/react-native-ble-manager/issues/590