### PR TITLE
Finish writing messages in the write queue before moving on…

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -79,7 +79,7 @@ public class Peripheral extends BluetoothGattCallback {
     private Runnable discoverServicesRunnable;
     private boolean commandQueueBusy = false;
 
-    private List<byte[]> writeQueue = new ArrayList<>();
+    private final Queue<byte[]> writeQueue = new LinkedList<>();
 
     public Peripheral(BluetoothDevice device, int advertisingRSSI, byte[] scanRecord, ReactContext reactContext) {
         this.device = device;
@@ -519,27 +519,28 @@ public class Peripheral extends BluetoothGattCallback {
         super.onCharacteristicWrite(gatt, characteristic, status);
 
         mainHandler.post(() -> {
-            if (writeQueue.size() > 0) {
-                byte[] data = writeQueue.get(0);
-                writeQueue.remove(0);
-                doWrite(characteristic, data, null);
-            } else if (status != BluetoothGatt.GATT_SUCCESS) {
-                if (status == GATT_AUTH_FAIL || status == GATT_INSUFFICIENT_AUTHENTICATION) {
-                    Log.d(BleManager.LOG_TAG, "Write needs bonding");
-                    // *not* doing completedCommand()
-                    return;
+            if (!writeQueue.isEmpty()) {
+                byte[] data = writeQueue.poll();
+                doWrite(characteristic, data);
+            } else {
+                if (status != BluetoothGatt.GATT_SUCCESS) {
+                    if (status == GATT_AUTH_FAIL || status == GATT_INSUFFICIENT_AUTHENTICATION) {
+                        Log.d(BleManager.LOG_TAG, "Write needs bonding");
+                        // *not* doing completedCommand()
+                        return;
+                    }
+                    for (Callback writeCallback : writeCallbacks) {
+                        writeCallback.invoke("Error writing " + characteristic.getUuid() + " status=" + status, null);
+                    }
+                    writeCallbacks.clear();
+                } else if (!writeCallbacks.isEmpty()) {
+                    for (Callback writeCallback : writeCallbacks) {
+                        writeCallback.invoke();
+                    }
+                    writeCallbacks.clear();
                 }
-                for (Callback writeCallback : writeCallbacks) {
-                    writeCallback.invoke("Error writing " + characteristic.getUuid() + " status=" + status, null);
-                }
-                writeCallbacks.clear();
-            } else if (!writeCallbacks.isEmpty()) {
-                for (Callback writeCallback : writeCallbacks) {
-                    writeCallback.invoke();
-                }
-                writeCallbacks.clear();
+                completedCommand();
             }
-            completedCommand();
         });
     }
 
@@ -1056,25 +1057,26 @@ public class Peripheral extends BluetoothGattCallback {
         return null;
     }
 
-    public boolean doWrite(final BluetoothGattCharacteristic characteristic, byte[] data, final Callback callback) {
-        final byte[] copyOfData = copyOf(data);
-        return enqueue(new Runnable() {
-            @Override
-            public void run() {
-                characteristic.setValue(copyOfData);
-                if (characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-                        && callback != null) {
-                    writeCallbacks.addLast(callback);
-                }
-                if (!gatt.writeCharacteristic(characteristic)) {
-                    // write without response, caller will handle the callback
-                    for (Callback writeCallback : writeCallbacks) {
-                        writeCallback.invoke("Write failed", null);
-                    }
-                    writeCallbacks.clear();
-                    completedCommand();
-                }
+    private void doWrite(final BluetoothGattCharacteristic characteristic, final byte[] data) {
+        characteristic.setValue(data);
+        if (!gatt.writeCharacteristic(characteristic)) {
+            // write without response, caller will handle the callback
+            for (Callback writeCallback : writeCallbacks) {
+                writeCallback.invoke("Write failed", null);
             }
+            writeCallbacks.clear();
+            completedCommand();
+        }
+    }
+
+    private boolean enqueueWrite(final BluetoothGattCharacteristic characteristic, byte[] data, final Callback callback) {
+        final byte[] copyOfData = copyOf(data);
+        return enqueue(() -> {
+            if (characteristic.getWriteType() == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                && callback != null) {
+                writeCallbacks.addLast(callback);
+            }
+            doWrite(characteristic, copyOfData);
         });
     }
 
@@ -1100,7 +1102,7 @@ public class Peripheral extends BluetoothGattCallback {
             characteristic.setWriteType(writeType);
 
             if (data.length <= maxByteSize) {
-                if (!doWrite(characteristic, data, callback)) {
+                if (!enqueueWrite(characteristic, data, callback)) {
                     callback.invoke("Write failed");
                 } else {
                     if (BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE == writeType) {
@@ -1130,21 +1132,21 @@ public class Peripheral extends BluetoothGattCallback {
 
                 if (BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT == writeType) {
                     writeQueue.addAll(splittedMessage);
-                    if (!doWrite(characteristic, firstMessage, callback)) {
+                    if (!enqueueWrite(characteristic, firstMessage, callback)) {
                         writeQueue.clear();
                         callback.invoke("Write failed");
                     }
                 } else {
                     try {
                         boolean writeError = false;
-                        if (!doWrite(characteristic, firstMessage, callback)) {
+                        if (!enqueueWrite(characteristic, firstMessage, callback)) {
                             writeError = true;
                             callback.invoke("Write failed");
                         }
                         if (!writeError) {
                             Thread.sleep(queueSleepTime);
                             for (byte[] message : splittedMessage) {
-                                if (!doWrite(characteristic, message, callback)) {
+                                if (!enqueueWrite(characteristic, message, callback)) {
                                     writeError = true;
                                     callback.invoke("Write failed");
                                     break;


### PR DESCRIPTION
…to the next command.

If you call `BleManager.write()` multiple times without `await`ing, there was a chance the message fragments could get interleaved and corrupted. This change keeps the current command active while the write queue is not empty, so that new writes don't clobber it.

I also created a test branch to verify this fix, but I had to make a bunch of changes to get it to run as a unit test. I don't know if those changes will break anything else, so I left them out. It's here if you're interested: https://github.com/perfectco/react-native-ble-manager/tree/feat/test