### PR TITLE
ios: fix willRestoreState event

### DIFF
--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -751,7 +751,7 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
                     peripheral.delegate = self
                 }
                 
-                NotificationCenter.default.post(name: Notification.Name("BleManagerCentralManagerWillRestoreState"), object: nil, userInfo: ["peripherals": data])
+                self.sendEvent(withName:"BleManagerCentralManagerWillRestoreState", body: ["peripherals": data])
             }
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,13 @@ export interface BleManagerDidUpdateNotificationStateForEvent {
 }
 
 /**
+ * [iOS only]
+ */
+export interface BleManagerCentralManagerWillRestoreState {
+  peripherals: Peripheral[];
+}
+
+/**
  * [Android only]
  *
  * Associate callback received a failure or failed to start the intent to


### PR DESCRIPTION
The event should be sent to the javascript listeners, not broadcasted to the iOS notification center.

Add typescript type for the event.

The event isn't currently working at all, because its send to the wrong place.