### PR TITLE
ios: Fix incorrect double -> NSNumber conversion

### DIFF
--- a/ios/BleManager.mm
+++ b/ios/BleManager.mm
@@ -214,7 +214,7 @@ RCT_EXPORT_MODULE()
     [_swBleManager startNotificationWithBuffer:peripheralUUID
                                    serviceUUID:serviceUUID
                             characteristicUUID:characteristicUUID
-                                  bufferLength:(double)bufferLength
+                                  bufferLength:@(bufferLength)
                                       callback:callback];
 }
 


### PR DESCRIPTION
Fixed an iOS build failure caused by incorrect double to NSNumber conversion
I also tested build and run.

https://github.com/aoiyu/react-native-ble-manager/blob/211062263fdf604a548e1d23a3b6556a4707f21c/ios/BleManager.mm#L217-L217

fixes #1307

Please let me know if you need any additional information or changes. 