### PR TITLE
feat(v11): Expose getCentralManager and getInstance methods

### DIFF
--- a/ios/BleManager.h
+++ b/ios/BleManager.h
@@ -2,4 +2,13 @@
 #import "React/RCTEventEmitter.h"
 #import <CoreBluetooth/CoreBluetooth.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
+@interface BleManager : RCTEventEmitter <RCTBridgeModule, CBCentralManagerDelegate>
+
++ (nullable CBCentralManager *)getCentralManager;
++ (nullable BleManager *)getInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/BleManager.swift
+++ b/ios/BleManager.swift
@@ -1193,11 +1193,11 @@ class BleManager: RCTEventEmitter, CBCentralManagerDelegate, CBPeripheralDelegat
     }
     
     
-    static func getCentralManager() -> CBCentralManager? {
+    @objc static func getCentralManager() -> CBCentralManager? {
         return sharedManager
     }
     
-    static func getInstance() -> BleManager? {
+    @objc static func getInstance() -> BleManager? {
         return shared
     }
     


### PR DESCRIPTION
Allow to access `getCentralManager` and `getInstance` methods in AppDelegate. Related to [this](https://github.com/innoveit/react-native-ble-manager/issues/664) question. Accessing these methods allows to combine this lib with nordic-dfu, as stated in their [docs](https://github.com/Pilloxa/react-native-nordic-dfu?tab=readme-ov-file#bluetooth-integration)