### PR TITLE
docs: add table of contents to events and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ npm run build
 
 > if you are modifying the typescript files of the library (in `src/`) on the fly, you can run `npm run watch` instead. If you are modifying files from the native counterparts, you'll need to rebuild the whole app for your target environnement (`npm run android/ios`).
 
+### Updating documentation
+
+Edit files in `docs/`, then test locally with:
+```shell
+cd docs
+bundle install
+bundle exec jekyll serve --watch --baseurl /
+```
+Then open http://localhost:4000/ 
+
 ## Generate the native code from specs
 A react-native project is needed to generate the code via *codegen*.
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -64,15 +64,17 @@ GEM
     rexml (3.3.9)
     rouge (3.30.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.58.3)
+    sass-embedded (1.58.3-arm64-darwin)
       google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
+    sass-embedded (1.58.3-x86_64-linux-gnu)
+      google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
     webrick (1.9.1)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
   x86_64-linux

--- a/docs/events.markdown
+++ b/docs/events.markdown
@@ -6,7 +6,17 @@ nav_order: 2
 parent: Usage
 ---
 
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
 # Events
+{: .no_toc }
 
 Since react-native version 0.76, events are handled with specific methods that return the listener.
 

--- a/docs/methods.markdown
+++ b/docs/methods.markdown
@@ -6,7 +6,17 @@ nav_order: 1
 parent: Usage
 ---
 
+<details markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
 # Methods
+{: .no_toc }
 
 ## start(options)
 


### PR DESCRIPTION
There's 35 methods, so that ToC starts closed.

Also adds instructions for testing docs locally in the README

Fixes #1332