### PR TITLE
fix: removing event listeners in invalidate

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -973,6 +973,11 @@ class BleManager extends NativeBleManagerSpec {
     @Override
     public void invalidate() {
         try {
+            context.unregisterReceiver(mReceiver);
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "Receiver not registered or already unregistered", e);
+        }
+        try {
             // Disconnect all known peripherals, otherwise android system will think we are still connected
             // while we have lost the gatt instance
             disconnectPeripherals();


### PR DESCRIPTION
This is a PR to fix the errors like

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.facebook.react.bridge.CxxCallbackImpl.invoke(java.lang.Object[])' on a null object reference
   at it.innove.NativeBleManagerSpec.emitOnDidUpdateState(NativeBleManagerSpec.java:46)
   at it.innove.BleManager$MyBroadcastReceiver.onReceive(BleManager.java:142)
```


 ```
Fatal Exception: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.bluetooth.adapter.action.STATE_CHANGED flg=0x5000010 (has extras) } in it.innove.BleManager$2@48d9436
   at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0$LoadedApk$ReceiverDispatcher$Args(LoadedApk.java:1708)
   at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run(:2)
   at android.os.Handler.handleCallback(Handler.java:978)
   at android.os.Handler.dispatchMessage(Handler.java:104)
   at android.os.Looper.loopOnce(Looper.java:238)
   at android.os.Looper.loop(Looper.java:357)
   at android.app.ActivityThread.main(ActivityThread.java:8103)
   at java.lang.reflect.Method.invoke(Method.java)
   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1026)
```


I know the crash is triggered when a callback (likely the one stored in something like mEventEmitterCallback) is null at the time it’s invoked. But it seems like unregistering the broadcast receivers in invalidate() would help prevent events from being fired after the module is torn down, which in turn should stop those late callbacks from being attempted.