### PR TITLE
Ensure enable bluetooth callback is set to null on exception

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -291,15 +291,16 @@ class BleManager extends NativeBleManagerSpec {
             return;
         }
         if (!getBluetoothAdapter().isEnabled()) {
-            enableBluetoothCallback = callback;
             Intent intentEnable = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
             if (getCurrentActivity() == null)
                 callback.invoke("Current activity not available");
             else {
+                enableBluetoothCallback = callback;
                 try {
                     getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
                 } catch (Exception e) {
-                    callback.invoke("Current activity not available");
+                    enableBluetoothCallback = null;
+                    callback.invoke("Error starting enable bluetooth activity");
                 }
 
             }


### PR DESCRIPTION
I had an issue in my application which was causing a Java crash on Android on the call to enableBluetoothCallback.invoke() in BleManager.java.
While I was able to fix it at the Javascript level, by ensuring I had got Bluetooth permission before calling enableBluetooth, I thought that the Java code should also be more robust against this, in case of anyone makes the same mistake, or finds another way to trigger the same thing.

The proposed fix is to make sure that "enableBluetoothCallback" is set to "callback", only just before we call startActivityForResult, and to set it to null in case startActivityForResult throws an exception. These mean it should never be left 'hanging' containing an already-used callback.

The fix/scenario was tested within my application.