### PR TITLE
[backport] Ensure enable bluetooth callback is set to null on exception (#1367)

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -188,16 +188,17 @@ class BleManager extends ReactContextBaseJavaModule {
             return;
         }
         if (!getBluetoothAdapter().isEnabled()) {
-            enableBluetoothCallback = callback;
             Intent intentEnable = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
             if (getCurrentActivity() == null)
                 callback.invoke("Current activity not available");
             else
                 {
+                    enableBluetoothCallback = callback;
                     try{
                         getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
                     }catch(Exception e){
-                        callback.invoke("Current activity not available");
+                        enableBluetoothCallback = null;
+                        callback.invoke("Error starting enable bluetooth activity");
                     }
 
                 }


### PR DESCRIPTION
This PR requests to backport PR #1367 into the v11.x branch.

As described in original PR, this protects against the possibility of trying to invoke the callback twice in case of an exception thrown by startActivityForResult, which causes Java exception on Android.