### PR TITLE
For v11.x: Fixing error handling around retrieveServicesCallback call natively

### DIFF
--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -294,12 +294,17 @@ public class Peripheral extends BluetoothGattCallback {
     public void onServicesDiscovered(BluetoothGatt gatt, int status) {
         super.onServicesDiscovered(gatt, status);
         mainHandler.post(() -> {
-            for (Callback retrieveServicesCallback : retrieveServicesCallbacks) {
-                WritableMap map = this.asWritableMap(gatt);
-                retrieveServicesCallback.invoke(null, map);
+            try {
+                for (Callback retrieveServicesCallback : retrieveServicesCallbacks) {
+                    WritableMap map = this.asWritableMap(gatt);
+                    retrieveServicesCallback.invoke(null, map);
+                }
+            } catch (Exception e) {
+                Log.e(BleManager.LOG_TAG, "Error invoking retrieveServicesCallback status=" + status, e);
+            } finally {
+                retrieveServicesCallbacks.clear();
+                completedCommand();
             }
-            retrieveServicesCallbacks.clear();
-            completedCommand();
         });
     }
 


### PR DESCRIPTION
**For v11.x**
The Android app is crashing randomly when we try to use multiple Bluetooth connections.

The stack trace is like

```
Exception com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
  at com.facebook.react.bridge.WritableNativeArray.pushNativeMap
  at com.facebook.react.bridge.WritableNativeArray.pushMap (WritableNativeArray.java:57)
  at com.facebook.react.bridge.Arguments.fromJavaArgs (Arguments.java:183)
  at com.facebook.react.bridge.CallbackImpl.invoke (CallbackImpl.java:31)
  at it.innove.Peripheral.lambda$onServicesDiscovered$2$it-innove-Peripheral (Peripheral.java:296)
  at it.innove.Peripheral$$ExternalSyntheticLambda0.run
  at android.os.Handler.handleCallback (Handler.java:883)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7405)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:502)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:980)
```

The reason is that accessing `retrieveServicesCallback` inside `mainHandler` has a concurrency issue, and so it's throwing an error inside `mainHandler`. This error is not caught, and so it crashes the whole app.

The fix is to wrap its usage with try try-catch to avoid this crash. 

This should fix https://github.com/innoveit/react-native-ble-manager/issues/1102 too

@marcosinigaglia, Can we merge this PR as its causing a random crash on Android 