### PR TITLE
[iOS] Feature: start notification with buffer

### DIFF
--- a/ios/NotifyBufferContainer.swift
+++ b/ios/NotifyBufferContainer.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+class NotifyBufferContainer {
+    public var items: Data
+    public let capacity: Int
+    
+    public var count: Int {
+        items.count
+    }
+    
+    public var remaining: Int {
+        capacity - items.count
+    }
+    
+    public var isBufferFull: Bool {
+        items.count >= capacity
+    }
+    
+    init(size: Int) {
+        self.capacity = size
+        self.items = Data(capacity: size)
+    }
+    
+    init(size: NSNumber) {
+        self.capacity = size.intValue
+        self.items = Data(capacity: size.intValue)
+    }
+    
+    public func resetBuffer() {
+        items.removeAll(keepingCapacity: true)
+    }
+    
+    public func put(_ value: Data) -> Data {
+        let remainingCapacity = self.remaining
+        let restLength = value.count - remainingCapacity
+        
+        let toInsert: Data
+        let rest: Data
+        if restLength > 0 {
+            toInsert = value.prefix(remainingCapacity)
+            rest = value.suffix(restLength)
+        }
+        else {
+            toInsert = value
+            rest = Data()
+        }
+        items.append(toInsert)
+        
+        return rest
+    }
+}

--- a/ios/NotifyBufferContainer.swift
+++ b/ios/NotifyBufferContainer.swift
@@ -32,6 +32,8 @@ class NotifyBufferContainer {
     
     public func put(_ value: Data) -> Data {
         let remainingCapacity = self.remaining
+        guard remainingCapacity > 0 else { return value }
+        
         let restLength = value.count - remainingCapacity
         
         let toInsert: Data

--- a/ios/NotifyBufferContainer.swift
+++ b/ios/NotifyBufferContainer.swift
@@ -21,11 +21,6 @@ class NotifyBufferContainer {
         self.items = Data(capacity: size)
     }
     
-    init(size: NSNumber) {
-        self.capacity = size.intValue
-        self.items = Data(capacity: size.intValue)
-    }
-    
     public func resetBuffer() {
         items.removeAll(keepingCapacity: true)
     }

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -854,10 +854,14 @@ import CoreBluetooth
             }
         }
         
-        for key in bufferedCharacteristics.keys {
-            if let keyString = key as String?, keyString.hasPrefix(peripheralUUIDString) {
-                bufferedCharacteristics.removeValue(forKey: key)
+        let bufferedCharacteristicsKeysToRemove = bufferedCharacteristics.keys.filter { key in
+            if let keyString = key as String? {
+                return keyString.hasPrefix(peripheralUUIDString)
             }
+            return false
+        }
+        for key in bufferedCharacteristicsKeysToRemove {
+            bufferedCharacteristics.removeValue(forKey: key)
         }
         
         connectedPeripherals.remove(peripheralUUIDString)

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -715,6 +715,10 @@ import CoreBluetooth
         if characteristic.isNotifying {
             let key = Helper.key(forPeripheral: (peripheral?.instance as CBPeripheral?)!, andCharacteristic: characteristic)
             insertCallback(callback, intoDictionary: &stopNotificationCallbacks, withKey: key)
+            
+            // Remove any buffered data if notification was started with buffer
+            self.bufferedCharacteristics.removeValue(forKey: key)
+            
             peripheral?.instance.setNotifyValue(false, for: characteristic)
             NSLog("Characteristic stopped notifying")
         } else {

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -675,7 +675,7 @@ import CoreBluetooth
         let key = Helper.key(forPeripheral: (peripheral.instance as CBPeripheral?)!, andCharacteristic: characteristic)
         insertCallback(callback, intoDictionary: &notificationCallbacks, withKey: key)
         
-        self.bufferedCharacteristics[key] = NotifyBufferContainer(size: bufferLength)
+        self.bufferedCharacteristics[key] = NotifyBufferContainer(size: bufferLength.intValue)
         
         peripheral.instance.setNotifyValue(true, for: characteristic)
     }

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -21,6 +21,7 @@ import CoreBluetooth
     private var writeQueue: Array<Any>
     private var notificationCallbacks: Dictionary<String, [RCTResponseSenderBlock]>
     private var stopNotificationCallbacks: Dictionary<String, [RCTResponseSenderBlock]>
+    private var bufferedCharacteristics: Dictionary<String, NotifyBufferContainer>
     
     private var connectedPeripherals: Set<String>
     
@@ -45,6 +46,7 @@ import CoreBluetooth
         writeQueue = []
         notificationCallbacks = [:]
         stopNotificationCallbacks = [:]
+        bufferedCharacteristics = [:]
         retrieveServicesLatches = [:]
         characteristicsLatches = [:]
         exactAdvertisingName = []

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -1140,6 +1140,10 @@ import CoreBluetooth
         if let error = error {
             NSLog("Error in didUpdateNotificationStateForCharacteristic: \(error)")
             
+            // Remove any buffered data if notification was started with buffer
+            let key = Helper.key(forPeripheral: peripheral, andCharacteristic: characteristic)
+            self.bufferedCharacteristics.removeValue(forKey: key)
+            
             self.bleManager?.emitOnDidUpdateNotificationState(for: [
                 "peripheral": peripheral.uuidAsString(),
                 "characteristic": characteristic.uuid.uuidString.lowercased(),

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -854,6 +854,12 @@ import CoreBluetooth
             }
         }
         
+        for key in bufferedCharacteristics.keys {
+            if let keyString = key as String?, keyString.hasPrefix(peripheralUUIDString) {
+                bufferedCharacteristics.removeValue(forKey: key)
+            }
+        }
+        
         connectedPeripherals.remove(peripheralUUIDString)
         if let e:Error = error {
             self.bleManager?.emit(onDisconnectPeripheral: ["peripheral": peripheralUUIDString, "domain": e._domain, "code": e._code, "description": e.localizedDescription])

--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -655,14 +655,29 @@ import CoreBluetooth
         peripheral?.instance.readValue(for: characteristic!)  // callback sends value
     }
     
-    
-    
     @objc public func startNotificationWithBuffer(_ peripheralUUID: String,
                                                   serviceUUID: String,
                                                   characteristicUUID: String,
                                                   bufferLength: NSNumber,
                                                   callback: @escaping RCTResponseSenderBlock) {
-        callback(["Not supported"])
+        NSLog("startNotificationWithBuffer")
+        
+        guard let context = getContext(
+            peripheralUUID,
+            serviceUUIDString: serviceUUID,
+            characteristicUUIDString: characteristicUUID,
+            prop: CBCharacteristicProperties.notify,
+            callback: callback
+        ) else { return }
+        guard let peripheral = context.peripheral else { return }
+        guard let characteristic = context.characteristic else { return }
+        
+        let key = Helper.key(forPeripheral: (peripheral.instance as CBPeripheral?)!, andCharacteristic: characteristic)
+        insertCallback(callback, intoDictionary: &notificationCallbacks, withKey: key)
+        
+        self.bufferedCharacteristics[key] = NotifyBufferContainer(size: bufferLength)
+        
+        peripheral.instance.setNotifyValue(true, for: characteristic)
     }
     
     @objc public func startNotification(_ peripheralUUID: String,

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,14 +364,14 @@ class BleManager {
    * @param buffer
    * @returns
    */
-  startNotificationUseBuffer(
+  startNotificationWithBuffer(
     peripheralId: string,
     serviceUUID: string,
     characteristicUUID: string,
     buffer: number
   ) {
     return new Promise<void>((fulfill, reject) => {
-      BleManagerModule.startNotificationUseBuffer(
+      BleManagerModule.startNotificationWithBuffer(
         peripheralId,
         serviceUUID,
         characteristicUUID,


### PR DESCRIPTION
This PR adds a similar implementation for `startNotificationWithBuffer()` for iOS as it is for Android right now.

Moreover, it fixes a mismatch in `index.ts` regarding the signature of this method to allow calls from the JS layer.

_Resolves #883_