### PR TITLE
Fix null device name handling in asWritableMap

### DIFF
--- a/android/src/main/java/it/innove/DefaultPeripheral.java
+++ b/android/src/main/java/it/innove/DefaultPeripheral.java
@@ -16,7 +16,7 @@ import com.facebook.react.bridge.WritableMap;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
-
+import java.util.Objects;
 
 @SuppressLint("MissingPermission")
 public class DefaultPeripheral extends Peripheral {


### PR DESCRIPTION
`device.getName()` can return `null`, while it is present on `ScanRecord`, try to get the name from `ScanRecord`, if `device` returns name as null.

Related issue https://github.com/innoveit/react-native-ble-manager/issues/1392