### PR TITLE
Feat/device setup

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -344,7 +344,7 @@ public class BleManager extends NativeBleManagerSpec {
 
     @SuppressLint("NewApi") // NOTE: constructor checks the API version.
     @ReactMethod
-    public void companionScan(ReadableArray serviceUUIDs, ReadableMap options, Callback callback) {
+    public void deviceSetupScan(ReadableArray serviceUUIDs, ReadableMap options, Callback callback) {
         if (this.companionScanner == null) {
             callback.invoke("not supported");
         } else {
@@ -353,7 +353,7 @@ public class BleManager extends NativeBleManagerSpec {
     }
 
     @ReactMethod
-    public void supportsCompanion(Callback callback) {
+    public void supportsDeviceSetup(Callback callback) {
         callback.invoke(companionScanner != null);
     }
 
@@ -885,7 +885,7 @@ public class BleManager extends NativeBleManagerSpec {
     }
 
     @ReactMethod
-    public void getAssociatedPeripherals(Callback callback) {
+    public void getAssociatedDevices(Callback callback) {
         Log.d(LOG_TAG, "Get associated peripherals");
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
             callback.invoke("Not supported");
@@ -901,7 +901,7 @@ public class BleManager extends NativeBleManagerSpec {
     }
 
     @ReactMethod
-    public void removeAssociatedPeripheral(String address, Callback callback) {
+    public void removeAssociatedDevice(String address, Callback callback) {
         Log.d(LOG_TAG, "Remove associated peripheral: " + address);
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
             callback.invoke("Not supported");

--- a/android/src/main/java/it/innove/CompanionScanner.java
+++ b/android/src/main/java/it/innove/CompanionScanner.java
@@ -31,6 +31,8 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
+import java.util.Objects;
+
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class CompanionScanner {
 
@@ -71,12 +73,12 @@ public class CompanionScanner {
                     if (peripheral != null && scanCallback != null) {
                         scanCallback.invoke(null, peripheral.asWritableMap());
                         scanCallback = null;
-                        bleManager.emitOnCompanionPeripheral(peripheral.asWritableMap());
+                        bleManager.emitOnDeviceSetupSelected(peripheral.asWritableMap());
                     }
                 } else {
                     scanCallback.invoke(null, null);
                     scanCallback = null;
-                    bleManager.emitOnCompanionPeripheral(null);
+                    bleManager.emitOnDeviceSetupSelected(null);
                 }
             } else {
                 // No device, user cancelled?
@@ -88,7 +90,7 @@ public class CompanionScanner {
                 scanCallback.invoke(null, peripheral != null ? peripheral.asWritableMap() : null);
                 scanCallback = null;
             }
-            bleManager.emitOnCompanionPeripheral(peripheral != null ? peripheral.asWritableMap() : null);
+            bleManager.emitOnDeviceSetupSelected(peripheral != null ? peripheral.asWritableMap() : null);
         }
     };
 
@@ -110,7 +112,7 @@ public class CompanionScanner {
                 .setSingleDevice(options.hasKey("single") && options.getBoolean("single")) ;
 
         for (int i = 0; i < serviceUUIDs.size(); i++) {
-            final ParcelUuid uuid = new ParcelUuid(UUIDHelper.uuidFromString(serviceUUIDs.getString(i)));
+            final ParcelUuid uuid = new ParcelUuid(UUIDHelper.uuidFromString(Objects.requireNonNull(serviceUUIDs.getString(i))));
             Log.d(LOG_TAG, "Filter service: " + uuid);
 
             builder = builder
@@ -144,15 +146,15 @@ public class CompanionScanner {
                 }
 
                 WritableMap map = Arguments.createMap();
-                map.putString("error", charSequence.toString());
-                bleManager.emitOnCompanionFailure(map);
+                map.putString("error", charSequence != null ? charSequence.toString() : "");
+                bleManager.emitOnDeviceSetupFailure(map);
             }
 
             @Override
             public void onDeviceFound(@NonNull IntentSender intentSender) {
                 Log.d(LOG_TAG, "companion device found");
                 try {
-                    reactContext.getCurrentActivity().startIntentSenderForResult(
+                    Objects.requireNonNull(reactContext.getCurrentActivity()).startIntentSenderForResult(
                             intentSender, SELECT_DEVICE_REQUEST_CODE, null, 0, 0, 0
                     );
                 } catch (IntentSender.SendIntentException e) {
@@ -166,7 +168,7 @@ public class CompanionScanner {
 
                     WritableMap map = Arguments.createMap();
                     map.putString("error", msg);
-                    bleManager.emitOnCompanionFailure(map);
+                    bleManager.emitOnDeviceSetupFailure(map);
                 }
             }
         }, null);

--- a/example/app.config.js
+++ b/example/app.config.js
@@ -13,6 +13,12 @@ export default ({ config }) => {
     },
     ios: {
       bundleIdentifier: 'it.innove.example.ble',
+      infoPlist: {
+        NSAccessorySetupKitSupports: ['Bluetooth'],
+        NSAccessorySetupBluetoothServices: [
+          'C219DA19-A018-405F-AF8E-BC98AD9FFAEC',
+        ],
+      },
     },
     plugins: [
       [

--- a/example/components/ScanDevicesScreen.tsx
+++ b/example/components/ScanDevicesScreen.tsx
@@ -76,7 +76,7 @@ const ScanDevicesScreen = () => {
         console.debug('[startScan] starting scan...');
         setIsScanning(true);
         BleManager.scan({
-          serviceUUIDStrings: SERVICE_UUIDS,
+          serviceUUIDs: SERVICE_UUIDS,
           seconds: SECONDS_TO_SCAN_FOR,
           allowDuplicates: ALLOW_DUPLICATES,
           matchMode: BleScanMatchMode.Sticky,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -39,7 +39,7 @@
       }
     },
     "..": {
-      "version": "12.3.0",
+      "version": "12.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^19.6.0",

--- a/ios/BleManager.h
+++ b/ios/BleManager.h
@@ -16,8 +16,8 @@
 - (void)emitOnPeripheralDidBond:(NSDictionary *)value;
 - (void)emitOnCentralManagerWillRestoreState:(NSDictionary *)value;
 - (void)emitOnDidUpdateNotificationStateFor:(NSDictionary *)value;
-- (void)emitOnCompanionPeripheral:(NSDictionary *)value;
-- (void)emitOnCompanionFailure:(NSDictionary *)value;
+- (void)emitOnDeviceSetupSelected:(NSDictionary *)value;
+- (void)emitOnDeviceSetupFailure:(NSDictionary *)value;
 + (nullable CBCentralManager *)getCentralManager;
 + (nullable SwiftBleManager *)getInstance;
 @end
@@ -34,8 +34,8 @@
 - (void)emitOnPeripheralDidBond:(NSDictionary *)value;
 - (void)emitOnCentralManagerWillRestoreState:(NSDictionary *)value;
 - (void)emitOnDidUpdateNotificationStateFor:(NSDictionary *)value;
-- (void)emitOnCompanionPeripheral:(NSDictionary *)value;
-- (void)emitOnCompanionFailure:(NSDictionary *)value;
+- (void)emitOnDeviceSetupSelected:(NSDictionary *)value;
+- (void)emitOnDeviceSetupFailure:(NSDictionary *)value;
 @end
 
 #endif

--- a/ios/BleManager.mm
+++ b/ios/BleManager.mm
@@ -44,10 +44,10 @@ RCT_EXPORT_MODULE()
     [_swBleManager checkState:callback];
 }
 
-- (void)companionScan:(NSArray *)serviceUUIDs
+- (void)deviceSetupScan:(NSArray *)serviceUUIDs
                option:(NSDictionary *)option
              callback:(RCTResponseSenderBlock)callback {
-    [_swBleManager companionScan:serviceUUIDs option:option callback:callback];
+    [_swBleManager deviceSetupScan:serviceUUIDs option:option callback:callback];
 }
 
 - (void)connect:(NSString *)peripheralUUID
@@ -74,8 +74,8 @@ RCT_EXPORT_MODULE()
     [_swBleManager enableBluetooth:callback];
 }
 
-- (void)getAssociatedPeripherals:(RCTResponseSenderBlock)callback {
-    [_swBleManager getAssociatedPeripherals:callback];
+- (void)getAssociatedDevices:(RCTResponseSenderBlock)callback {
+    [_swBleManager getAssociatedDevices:callback];
 }
 
 - (void)getBondedPeripherals:(RCTResponseSenderBlock)callback {
@@ -147,9 +147,9 @@ RCT_EXPORT_MODULE()
     [_swBleManager refreshCache:peripheralUUID callback:callback];
 }
 
-- (void)removeAssociatedPeripheral:(NSString *)peripheralUUID
+- (void)removeAssociatedDevice:(NSString *)peripheralUUID
                           callback:(RCTResponseSenderBlock)callback {
-    [_swBleManager removeAssociatedPeripheral:peripheralUUID callback:callback];
+    [_swBleManager removeAssociatedDevice:peripheralUUID callback:callback];
 }
 
 - (void)removeBond:(NSString *)peripheralUUID
@@ -238,8 +238,8 @@ RCT_EXPORT_MODULE()
     [_swBleManager stopScan:callback];
 }
 
-- (void)supportsCompanion:(RCTResponseSenderBlock)callback {
-    [_swBleManager supportsCompanion:callback];
+- (void)supportsDeviceSetup:(RCTResponseSenderBlock)callback {
+    [_swBleManager supportsDeviceSetup:callback];
 }
 
 - (void)write:(NSString *)peripheralUUID

--- a/src/NativeBleManager.ts
+++ b/src/NativeBleManager.ts
@@ -176,18 +176,18 @@ export interface Spec extends TurboModule {
 
   setName(name: string): void;
 
-  getAssociatedPeripherals(
+  getAssociatedDevices(
     callback: (error: CallbackError, peripherals: Peripheral[] | null) => void
   ): void;
 
-  removeAssociatedPeripheral(
+  removeAssociatedDevice(
     peripheralUUID: string,
     callback: (error: CallbackError) => void
   ): void;
 
-  supportsCompanion(callback: (supports: boolean) => void): void;
+  supportsDeviceSetup(callback: (supports: boolean) => void): void;
 
-  companionScan(
+  deviceSetupScan(
     serviceUUIDs: string[],
     option: Object,
     callback: (error: CallbackError, peripheral: Peripheral | null) => void
@@ -205,8 +205,8 @@ export interface Spec extends TurboModule {
   readonly onPeripheralDidBond: EventEmitter<EventPeripheralDidBond>;
   readonly onCentralManagerWillRestoreState: EventEmitter<EventCentralManagerWillRestoreState>;
   readonly onDidUpdateNotificationStateFor: EventEmitter<EventDidUpdateNotificationStateFor>;
-  readonly onCompanionPeripheral: EventEmitter<EventCompanionPeripheral>;
-  readonly onCompanionFailure: EventEmitter<EventCompanionFailure>;
+  readonly onDeviceSetupSelected: EventEmitter<EventDeviceSetupSelected>;
+  readonly onDeviceSetupFailure: EventEmitter<EventDeviceSetupFailure>;
 }
 
 export default TurboModuleRegistry.get<Spec>('BleManager') as Spec;
@@ -360,7 +360,7 @@ export type EventDidUpdateNotificationStateFor = {
   code?: number | null;
 };
 
-export type EventCompanionPeripheral = {
+export type EventDeviceSetupSelected = {
   id: string;
   name: string;
   rssi: number;
@@ -374,4 +374,4 @@ export type EventCompanionPeripheral = {
   };
 };
 
-export type EventCompanionFailure = { error: string };
+export type EventDeviceSetupFailure = { error: string };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,11 @@ import {
   BleState,
   ConnectOptions,
   ConnectionPriority,
-  CompanionScanOptions,
   Peripheral,
   PeripheralInfo,
   ScanOptions,
   StartOptions,
+  DeviceSetupScanOptions,
 } from './types';
 import { CallbackError } from './NativeBleManager';
 export * from './types';
@@ -712,9 +712,9 @@ class BleManager {
    *
    * @returns
    */
-  getAssociatedPeripherals() {
+  getAssociatedDevices() {
     return new Promise<Peripheral[]>((fulfill, reject) => {
-      BleManagerModule.getAssociatedPeripherals(
+      BleManagerModule.getAssociatedDevices(
         (error: string | null, peripherals: Peripheral[] | null) => {
           if (error) {
             reject(error);
@@ -732,9 +732,9 @@ class BleManager {
    * @returns Promise that resolves once the peripheral has been removed. Rejects
    *          if no association is found.
    */
-  removeAssociatedPeripheral(peripheralId: string) {
+  removeAssociatedDevice(peripheralId: string) {
     return new Promise<void>((fulfill, reject) => {
-      BleManagerModule.removeAssociatedPeripheral(
+      BleManagerModule.removeAssociatedDevice(
         peripheralId,
         (error: string | null) => {
           if (error !== null) {
@@ -748,28 +748,26 @@ class BleManager {
   }
 
   /**
-   * [Android only]
    *
-   * Check if current device supports companion device manager.
+   * Check if current device supports device setup.
    *
    * @return Promise resolving to a boolean.
    */
-  supportsCompanion() {
+  supportsDeviceSetup() {
     return new Promise<boolean>((fulfill) => {
-      BleManagerModule.supportsCompanion((supports: boolean) =>
+      BleManagerModule.supportsDeviceSetup((supports: boolean) =>
         fulfill(supports)
       );
     });
   }
 
   /**
-   * [Android only, API 26+]
    *
-   * Start companion scan.
+   * Start device setup scan.
    */
-  companionScan(serviceUUIDs: string[], options: CompanionScanOptions = {}) {
+  deviceSetupScan(serviceUUIDs: string[], options: DeviceSetupScanOptions = {}) {
     return new Promise<Peripheral | null>((fulfill, reject) => {
-      BleManagerModule.companionScan(
+      BleManagerModule.deviceSetupScan(
         serviceUUIDs,
         options,
         (error: string | null, peripheral: Peripheral | null) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,11 +170,15 @@ export interface ScanOptions {
   useScanIntent?: boolean;
 }
 
-export interface CompanionScanOptions {
+export interface DeviceSetupScanOptions {
   /**
    * Scan only for a single peripheral.
    */
   single?: boolean;
+  /**
+   * Enable verbose native logging during device setup.
+   */
+  verboseLogging?: boolean;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a broad renaming and refactoring of the "companion" device setup feature across both Android and iOS platforms, standardizing terminology to "device setup" and improving code robustness and clarity. It also updates the example app to use the new APIs, enhances Bluetooth scanning logic, and adds iOS 18 AccessorySetupKit support for device setup. Below are the most important changes grouped by theme:

**API and Naming Standardization:**

* Renamed all "companion" methods, events, and variables to "device setup" equivalents in both Android (`BleManager.java`, `CompanionScanner.java`) and iOS (`BleManager.h`, `BleManager.mm`, `SwiftBleManager.swift`), including exported methods like `companionScan` → `deviceSetupScan`, `supportsCompanion` → `supportsDeviceSetup`, and related event emitters. [[1]](diffhunk://#diff-bd950e1fc48f88bc003e76468c61874525303021b84c27ff8a300171b49517d5L347-R347) [[2]](diffhunk://#diff-bd950e1fc48f88bc003e76468c61874525303021b84c27ff8a300171b49517d5L356-R356) [[3]](diffhunk://#diff-bd950e1fc48f88bc003e76468c61874525303021b84c27ff8a300171b49517d5L888-R888) [[4]](diffhunk://#diff-bd950e1fc48f88bc003e76468c61874525303021b84c27ff8a300171b49517d5L904-R904) [[5]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL74-R81) [[6]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL91-R93) [[7]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL147-R157) [[8]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL169-R171) [[9]](diffhunk://#diff-9209ebfa4a7576ce80a36ceb996007569c2713a026d866d54e72a6231aee771fL19-R20) [[10]](diffhunk://#diff-9209ebfa4a7576ce80a36ceb996007569c2713a026d866d54e72a6231aee771fL37-R38) [[11]](diffhunk://#diff-aa99833a551dade738c87373859e7d55546628d2bb8dd31325b7183f5ef2ce85L47-R50) [[12]](diffhunk://#diff-aa99833a551dade738c87373859e7d55546628d2bb8dd31325b7183f5ef2ce85L77-R78) [[13]](diffhunk://#diff-aa99833a551dade738c87373859e7d55546628d2bb8dd31325b7183f5ef2ce85L150-R152) [[14]](diffhunk://#diff-aa99833a551dade738c87373859e7d55546628d2bb8dd31325b7183f5ef2ce85L241-R242)

**iOS Device Setup Support:**

* Added initial support for iOS 18's AccessorySetupKit, including a method to build a payload from an `ASAccessory`, and session management for accessory setup flows in `SwiftBleManager.swift`. [[1]](diffhunk://#diff-5b0571f4f5df28365a31733b44690b3e55af462f81c2d05cf00977ae37993461R1-R4) [[2]](diffhunk://#diff-5b0571f4f5df28365a31733b44690b3e55af462f81c2d05cf00977ae37993461R41-R100)

**Android Robustness Improvements:**

* Improved null-safety and error handling in `CompanionScanner.java` by using `Objects.requireNonNull` and checking for nulls before accessing values. [[1]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbR34-R35) [[2]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL113-R115) [[3]](diffhunk://#diff-227a6d8a41c3f9883a8e35d7478cc7c27041f9318c0e24f81e74c6fd8139c1fbL147-R157)

**Example App Updates:**

* Updated the example app to use the new "device setup" APIs, increased scan duration, set a specific service UUID, and improved Bluetooth initialization logic to ensure the BLE manager is started before scanning. Also cleaned up UI and button logic for device setup and Bluetooth enabling. [[1]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L32-R33) [[2]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L57-R70) [[3]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L85-R105) [[4]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L102-R118) [[5]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L257-R270) [[6]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L402-L412) [[7]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2R499-R500) [[8]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2L524-R530) [[9]](diffhunk://#diff-eac5f40cd9cf0fb942196e95baf3d739189165048c6704f3e3f9e5496ed8b2b2R543-L554)

**iOS Permissions:**

* Added required iOS AccessorySetupKit and Bluetooth permissions to the example app's `app.config.js` for iOS 18 compatibility.