### PR TITLE
Align the JSDocs with the docs

### DIFF
--- a/docs/events.markdown
+++ b/docs/events.markdown
@@ -69,7 +69,7 @@ The scanning found a new peripheral.
 - `rssi` - `Number` - the RSSI value
 - `advertising` - `JSON` - the advertising payload, here are some examples:
   - `isConnectable` - `Boolean`
-  - `serviceUUIDs` - `Array of String`
+  - `serviceUUIDs` - `String[]`
   - `manufacturerData` - `JSON` - contains a json with the company id as field and the custom value as raw `bytes` and `data` (Base64 encoded string)
   - `serviceData` - `JSON` - contains the raw `bytes` and `data` (Base64 encoded string)
   - `txPowerLevel` - `Int`
@@ -81,14 +81,14 @@ The scanning found a new peripheral.
 
 A characteristic notified a new value.
 
+> Event will only be emitted after successful `startNotification`.
+
 **Arguments**
 
-- `value` — `Array` — the read value
+- `value` — `Number[]` — the read value
 - `peripheral` — `String` — the id of the peripheral
 - `characteristic` — `String` — the UUID of the characteristic
 - `service` — `String` — the UUID of the characteristic
-
-> Event will only be emitted after successful `startNotification`.
 
 ---
 
@@ -130,15 +130,15 @@ Object with information about the device.
 
 This is fired when [`centralManager:WillRestoreState:`](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/1518819-centralmanager) is called (app relaunched in the background to handle a bluetooth event).
 
-**Arguments**
-
-- `peripherals` - `Array` - an array of previously connected peripherals.
-
 _For more on performing long-term bluetooth actions in the background:_
 
 [iOS Bluetooth State Preservation and Restoration](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10)
 
 [iOS Relaunch Conditions](https://developer.apple.com/documentation/technotes/tn3115-bluetooth-state-restoration-app-relaunch-rules/)
+
+**Arguments**
+
+- `peripherals` - `Array` - an array of previously connected peripherals.
 
 ---
 ### onDidUpdateNotificationStateFor [iOS only]

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,12 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @returns data as an array of numbers (which can be converted back to a Uint8Array (ByteArray) using something like [Buffer.from()](https://github.com/feross/buffer))
+   * Read the current value of the specified characteristic, you need to call `retrieveServices` method before.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @returns Data as an array of numbers (which can be converted back to a Uint8Array (ByteArray) using something like [Buffer.from()](https://github.com/feross/buffer))
    */
   read(peripheralId: string, serviceUUID: string, characteristicUUID: string) {
     return new Promise<number[]>((fulfill, reject) => {
@@ -67,11 +68,12 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @param descriptorUUID
+   * Read the current value of the specified descriptor, you need to call `retrieveServices` method before.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @param descriptorUUID The UUID of the descriptor.
    * @returns data as an array of numbers (which can be converted back to a Uint8Array (ByteArray) using something like [Buffer.from()](https://github.com/feross/buffer))
    */
   readDescriptor(
@@ -98,12 +100,13 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @param descriptorUUID
-   * @param data data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
+   * Write a value to the specified descriptor, you need to call `retrieveServices` method before.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @param descriptorUUID The UUID of the descriptor.
+   * @param data Data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
    * @returns
    */
   writeDescriptor(
@@ -132,9 +135,10 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @returns a promise resolving with the updated RSSI (`number`) if it succeeds.
+   * Read the current value of the RSSI.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @returns A promise resolving with the updated RSSI (`number`) if it succeeds.
    */
   readRSSI(peripheralId: string) {
     return new Promise<number>((fulfill, reject) => {
@@ -153,8 +157,11 @@ class BleManager {
 
   /**
    * [Android only]
-   * @param peripheralId
-   * @returns a promise that resolves to a boolean indicating if gatt was successfully refreshed or not.
+   * 
+   * Refreshes the peripheral's services and characteristics cache.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @returns A promise that resolves to a boolean indicating if gatt was successfully refreshed or not.
    */
   refreshCache(peripheralId: string) {
     return new Promise<boolean>((fulfill, reject) => {
@@ -172,9 +179,10 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUIDs [iOS only] optional filter of services to retrieve.
+   * Retrieve the peripheral's services and characteristics.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUIDs [iOS only] Optional filter of services to retrieve.
    * @returns
    */
   retrieveServices(peripheralId: string, serviceUUIDs: string[] = []) {
@@ -194,12 +202,13 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @param data data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
-   * @param maxByteSize optional, defaults to 20
+   * Write with response to the specified characteristic, you need to call `retrieveServices` method before.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @param data Data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
+   * @param maxByteSize Optional, defaults to 20
    * @returns
    */
   write(
@@ -228,13 +237,14 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @param data data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
-   * @param maxByteSize optional, defaults to 20
-   * @param queueSleepTime optional, defaults to 10. Only useful if data length is greater than maxByteSize.
+   * Write without response to the specified characteristic, you need to call `retrieveServices` method before.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @param data Data to write as an array of numbers (which can be converted from a Uint8Array (ByteArray) using something like [Buffer.toJSON().data](https://github.com/feross/buffer))
+   * @param maxByteSize Optional, defaults to 20
+   * @param queueSleepTime Optional, defaults to 10. Only useful if data length is greater than maxByteSize.
    * @returns
    */
   writeWithoutResponse(
@@ -264,6 +274,11 @@ class BleManager {
     });
   }
 
+  /**
+   * Attempts to connect to a peripheral. In many case if you can't connect you have to scan for the peripheral before.
+   * 
+   * > In iOS, attempts to connect to a peripheral do not time out (please see [Apple's doc](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518766-connect)), so you might need to set a timer explicitly if you don't want this behavior.
+   */
   connect(peripheralId: string, options?: ConnectOptions) {
     return new Promise<void>((fulfill, reject) => {
       if (!options) {
@@ -285,8 +300,13 @@ class BleManager {
 
   /**
    * [Android only]
-   * @param peripheralId
-   * @param peripheralPin optional. will be used to auto-bond if possible.
+   * 
+   * Start the bonding (pairing) process with the remote device.
+   * If you pass peripheralPin (optional), bonding will be auto (without manually entering the pin).
+   * > Ensure to make one bond request at a time.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param peripheralPin Optional. will be used to auto-bond if possible.
    * @returns
    */
   createBond(peripheralId: string, peripheralPin: string | null = null) {
@@ -307,7 +327,10 @@ class BleManager {
 
   /**
    * [Android only]
-   * @param peripheralId
+   * 
+   * Remove a paired device.
+   * 
+   * @param peripheralId The id/mac address of the peripheral
    * @returns
    */
   removeBond(peripheralId: string) {
@@ -323,9 +346,10 @@ class BleManager {
   }
 
   /**
-   *
-   * @param peripheralId
-   * @param force [Android only] defaults to true.
+   * Disconnect from a peripheral.
+   * 
+   * @param peripheralId The id/mac address of the peripheral to disconnect.
+   * @param force [Android only] Defaults to true. Don't wait for the disconnect state to close the Gatt client.
    * @returns
    */
   disconnect(peripheralId: string, force: boolean = true) {
@@ -344,6 +368,16 @@ class BleManager {
     });
   }
 
+  /**
+   * Start the notification on the specified characteristic, you need to call `retrieveServices` method before.
+   * 
+   * Events will be send to `onDidUpdateValueForCharacteristic` when the peripheral notifies a new value for the characteristic. 
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @returns 
+   */
   startNotification(
     peripheralId: string,
     serviceUUID: string,
@@ -367,10 +401,15 @@ class BleManager {
 
   /**
    * [Android only]
-   * @param peripheralId
-   * @param serviceUUID
-   * @param characteristicUUID
-   * @param buffer
+   * 
+   * Start the notification on the specified characteristic, you need to call `retrieveServices` method before.
+   * The buffer collect messages until the buffer of messages bytes reaches the limit defined with the `buffer` argument and then emit all the collected data.
+   * Useful to reduce the number of calls between the native and the react-native part in case of many messages.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @param buffer The capacity of the buffer (bytes) stored before emitting the data for the characteristic.
    * @returns
    */
   startNotificationWithBuffer(
@@ -396,6 +435,14 @@ class BleManager {
     });
   }
 
+  /**
+   * Stop the notification on the specified characteristic.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUID The UUID of the service.
+   * @param characteristicUUID The UUID of the characteristic.
+   * @returns 
+   */
   stopNotification(
     peripheralId: string,
     serviceUUID: string,
@@ -417,6 +464,10 @@ class BleManager {
     });
   }
 
+  /**
+   * Force the module to check the state of the native BLE manager and trigger an event for `onDidUpdateState`.
+   * @returns A promise containing the current BleState
+   */
   checkState() {
     return new Promise<BleState>((fulfill, _) => {
       BleManagerModule.checkState((state: BleState) => {
@@ -425,6 +476,9 @@ class BleManager {
     });
   }
 
+  /**
+   * Init the module. Don't call this multiple times.
+   */
   start(options?: StartOptions) {
     return new Promise<void>((fulfill, reject) => {
       if (options == null) {
@@ -457,8 +511,13 @@ class BleManager {
   }
 
   /**
-   *
-   * @param scanningOptions optional map of properties to fine-tune scan behavior, see DOCS.
+   * Scan for available peripherals.
+   * 
+   * See `onDiscoverPeripheral` to get live updates of devices being discovered.
+   * 
+   * See `getDiscoveredPeripherals` to get a list of discovered devices after a scan is completed.
+   * 
+   * @param scanningOptions Optional map of properties to fine-tune scan behavior, see DOCS.
    * @returns
    */
   scan(scanningOptions: ScanOptions = {}) {
@@ -524,6 +583,9 @@ class BleManager {
     });
   }
 
+  /**
+   * Stop the scanning.
+   */
   stopScan() {
     return new Promise<void>((fulfill, reject) => {
       BleManagerModule.stopScan((error: string | null) => {
@@ -553,8 +615,13 @@ class BleManager {
   }
 
   /**
-   *
-   * @param serviceUUIDs [optional] not used on android, optional on ios.
+   * Return the connected peripherals.
+   * 
+   * > In Android, Peripherals "advertising" property can be not set!
+   * > Will be available if peripheral was found through scan before connect.
+   * > This matches to current Android Bluetooth design specification.
+   * 
+   * @param serviceUUIDs [iOS only] Optional, only retrieve peripherals with these services. Ignored in Android.
    * @returns
    */
   getConnectedPeripherals(serviceUUIDs: string[] = []) {
@@ -578,6 +645,9 @@ class BleManager {
 
   /**
    * [Android only]
+   * 
+   * Return the bonded peripherals.
+   * 
    * @returns
    */
   getBondedPeripherals() {
@@ -598,6 +668,9 @@ class BleManager {
     });
   }
 
+  /**
+   * Return the discovered peripherals after a scan.
+   */
   getDiscoveredPeripherals() {
     return new Promise<Peripheral[]>((fulfill, reject) => {
       BleManagerModule.getDiscoveredPeripherals(
@@ -618,7 +691,11 @@ class BleManager {
 
   /**
    * [Android only]
-   * @param peripheralId
+   * 
+   * Removes a disconnected peripheral from the cached list.
+   * It is useful if the device is turned off, because it will be re-discovered upon turning on again.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
    * @returns
    */
   removePeripheral(peripheralId: string) {
@@ -637,8 +714,10 @@ class BleManager {
   }
 
   /**
-   * @param peripheralId
-   * @param serviceUUIDs [optional] not used on android, optional on ios.
+   * Check whether a specific peripheral is connected and return `true` or `false`.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param serviceUUIDs [iOS only] Optional, only retrieve peripherals with these services. Ignored in Android.
    * @returns
    */
   isPeripheralConnected(peripheralId: string, serviceUUIDs: string[] = []) {
@@ -652,8 +731,7 @@ class BleManager {
   }
 
   /**
-   * @param peripheralId
-   * @param serviceUUIDs [optional] not used on android, optional on ios.
+   * Checks whether the scan is in progress and return `true` or `false`.
    * @returns
    */
   isScanning() {
@@ -670,9 +748,9 @@ class BleManager {
 
   /**
    * [Android only, API 21+]
-   * @param peripheralId
-   * @param connectionPriority
-   * @returns a promise that resolves with a boolean indicating of the connection priority was changed successfully, or rejects with an error message.
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param connectionPriority The connection priority to be requested
+   * @returns A promise that resolves with a boolean indicating of the connection priority was changed successfully, or rejects with an error message.
    */
   requestConnectionPriority(
     peripheralId: string,
@@ -695,9 +773,12 @@ class BleManager {
 
   /**
    * [Android only, API 21+]
-   * @param peripheralId
-   * @param mtu size to be requested, in bytes.
-   * @returns a promise resolving with the negotiated MTU if it succeeded. Beware that it might not be the one requested due to device's BLE limitations on both side of the negotiation.
+   * 
+   * Request an MTU size used for a given connection.
+   * 
+   * @param peripheralId The id/mac address of the peripheral.
+   * @param mtu Size to be requested, in bytes.
+   * @returns A promise resolving with the negotiated MTU if it succeeded. Beware that it might not be the one requested due to device's BLE limitations on both side of the negotiation.
    */
   requestMTU(peripheralId: string, mtu: number) {
     return new Promise<number>((fulfill, reject) => {
@@ -717,6 +798,8 @@ class BleManager {
 
   /**
    * [Android only, API 26+]
+   * 
+   * Retrieve associated peripherals (from companion manager).
    *
    * @returns
    */
@@ -736,6 +819,9 @@ class BleManager {
 
   /**
    * [Android only, API 26+]
+   * 
+   * Remove an associated peripheral.
+   * 
    * @param peripheralId Peripheral to remove
    * @returns Promise that resolves once the peripheral has been removed. Rejects
    *          if no association is found.
@@ -758,7 +844,7 @@ class BleManager {
   /**
    * [Android only]
    *
-   * Check if current device supports companion device manager.
+   * Check if current device supports the companion device manager.
    *
    * @return Promise resolving to a boolean.
    */
@@ -773,7 +859,20 @@ class BleManager {
   /**
    * [Android only, API 26+]
    *
-   * Start companion scan.
+   * Scan for companion devices.
+   * 
+   * Rejects if the companion device manager is not supported on this device.
+   * 
+   * The promise it will eventually resolve with either:
+   * 
+   * 1.  peripheral if user selects one
+   * 2.  null if user "cancels" (i.e. doesn't select anything)
+   * 
+   * See `BleManager.supportsCompanion`.
+   * 
+   * See: https://developer.android.com/develop/connectivity/bluetooth/companion-device-pairing
+   * 
+   * @param serviceUUIDs List of service UUIDs to use as a filter
    */
   companionScan(serviceUUIDs: string[], options: CompanionScanOptions = {}) {
     return new Promise<Peripheral | null>((fulfill, reject) => {
@@ -793,6 +892,9 @@ class BleManager {
 
   /**
    * [Android only]
+   * 
+   * Create the request to set the name of the bluetooth adapter. (https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#setName(java.lang.String))
+   * 
    * @param name
    */
   setName(name: string) {
@@ -801,7 +903,7 @@ class BleManager {
 
   /**
    * [iOS only]
-   * @param peripheralId
+   * @param peripheralId The id/mac address of the peripheral.
    * @returns
    */
   getMaximumWriteValueLengthForWithoutResponse(peripheralId: string) {
@@ -821,7 +923,7 @@ class BleManager {
 
   /**
    * [iOS only]
-   * @param peripheralId
+   * @param peripheralId The id/mac address of the peripheral.
    * @returns
    */
   getMaximumWriteValueLengthForWithResponse(peripheralId: string) {
@@ -839,42 +941,86 @@ class BleManager {
     });
   }
 
+  /**
+   * The scanning found a new peripheral.
+   */
   onDiscoverPeripheral(callback: EventCallback<BleDiscoverPeripheralEvent>): EventSubscription {
     return BleManagerModule.onDiscoverPeripheral(callback);
   }
 
+  /**
+   * The scanning for peripherals is ended.
+   */
   onStopScan(callback: EventCallback<BleStopScanEvent>): EventSubscription {
     return BleManagerModule.onStopScan(callback);
   }
 
+  /**
+   * The BLE state changed.
+   */
   onDidUpdateState(callback: EventCallback<BleManagerDidUpdateStateEvent>): EventSubscription {
     return BleManagerModule.onDidUpdateState(callback);
   }
 
+  /**
+   * A peripheral was connected.
+   */
   onConnectPeripheral(callback: EventCallback<BleConnectPeripheralEvent>): EventSubscription {
     return BleManagerModule.onConnectPeripheral(callback);
   }
 
+  /**
+   * A peripheral was disconnected.
+   */
   onDisconnectPeripheral(callback: EventCallback<BleDisconnectPeripheralEvent>): EventSubscription {
     return BleManagerModule.onDisconnectPeripheral(callback);
   }
 
+  /**
+   * A characteristic notified a new value.
+   * 
+   * > Event will only be emitted after successful `startNotification`.
+   */
   onDidUpdateValueForCharacteristic(callback: EventCallback<BleManagerDidUpdateValueForCharacteristicEvent>): EventSubscription {
     return BleManagerModule.onDidUpdateValueForCharacteristic(callback);
   }
 
+  /**
+   * A bond with a peripheral was established.
+   */
   onPeripheralDidBond(callback: EventCallback<BleBondedPeripheralEvent>): EventSubscription {
     return BleManagerModule.onPeripheralDidBond(callback);
   }
 
+  /**
+   * [iOS only]
+   * 
+   * This is fired when [`centralManager:WillRestoreState:`](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/1518819-centralmanager) is called (app relaunched in the background to handle a bluetooth event).
+   * 
+   * _For more on performing long-term bluetooth actions in the background:_
+   * 
+   * [iOS Bluetooth State Preservation and Restoration](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10)
+   * 
+   * [iOS Relaunch Conditions](https://developer.apple.com/documentation/technotes/tn3115-bluetooth-state-restoration-app-relaunch-rules/)
+   */
   onCentralManagerWillRestoreState(callback: EventCallback<BleManagerCentralManagerWillRestoreState>): EventSubscription {
     return BleManagerModule.onCentralManagerWillRestoreState(callback);
   }
 
+  /**
+   * [iOS only]
+   * 
+   * The peripheral received a request to start or stop providing notifications for a specified characteristic's value.
+   */
   onDidUpdateNotificationStateFor(callback: EventCallback<BleManagerDidUpdateNotificationStateForEvent>): EventSubscription {
     return BleManagerModule.onDidUpdateNotificationStateFor(callback);
   }
 
+  /**
+   * User picked a device to associate with.
+   * 
+   * Null if the request was cancelled by the user.
+   */
   onCompanionPeripheral(callback: EventCallback<BleManagerCompanionPeripheral>): EventSubscription {
     return BleManagerModule.onCompanionPeripheral(callback);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 /**
- * android states: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#EXTRA_STATE
- * ios states: https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerstate
+ * Android states: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#EXTRA_STATE
+ * iOS states: https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerstate
  * */
 export enum BleState {
   /**
@@ -19,11 +19,11 @@ export enum BleState {
   On = 'on',
   Off = 'off',
   /**
-   * [android only]
+   * [Android only]
    */
   TurningOn = 'turning_on',
   /**
-   * [android only]
+   * [Android only]
    */
   TurningOff = 'turning_off',
 }
@@ -61,61 +61,84 @@ export interface CustomAdvertisingData {
 
 export interface StartOptions {
   /**
-   * [iOS only]
+   * [iOS only] Show or hide the alert if the bluetooth is turned off during initialization
    */
   showAlert?: boolean;
   /**
-   * [iOS only]
+   * [iOS only] Unique key to use for CoreBluetooth state restoration
    */
   restoreIdentifierKey?: string;
   /**
-   * [iOS only]
+   * [iOS only] Unique key to use for a queue identifier on which CoreBluetooth events will be dispatched
    */
   queueIdentifierKey?: string;
   /**
-   * [android only]
+   * [Android only] Force to use the LegacyScanManager
    */
   forceLegacy?: boolean;
 }
 
 export interface ConnectOptions {
   /**
-   * [android only]
+   * [Android only] whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true) ([`Android doc`](<https://developer.android.com/reference/android/bluetooth/BluetoothDevice?hl=en#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback,%20int,%20int)>))
    */
   autoconnect?: boolean;
   /**
-   * [android only]
+   * [Android only] corresponding to the preferred phy channel ([`Android doc`](<https://developer.android.com/reference/android/bluetooth/BluetoothDevice?hl=en#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback,%20int,%20int)>))
    */
   phy?: BleScanPhyMode;
 }
 
 /**
- * [android only]
+ * [Android only]
  * https://developer.android.com/reference/android/bluetooth/le/ScanSettings
  */
 export interface ScanOptions {
+  /**
+   * The UUIDs of the services to look for.
+   */
   serviceUUIDs?: string[];
+  /**
+   * The amount of seconds to scan. If not set or set to `0`, scans until `stopScan()` is called.
+   */
   seconds?: number;
   /**
-   *  iOS only: whether to allow duplicate peripheral during a scan
+   * In Android this is a ScanFilter, if present it restricts scan results to devices with a specific advertising name.
+   * This is a whole word match, not a partial search.
+   * Use with caution, it's behavior is tricky and seems to be the following:
+   * if `callbackType` is set to `AllMatches`, only the completeLocalName will be used for filtering.
+   * if `callbackType` is set to `FirstMatch`, the shortenedLocalName will be used for filtering.
+   * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
+   * 
+   * In iOS, this is a whole word match, not a partial search.
+   */
+  exactAdvertisingName?: string | string[];
+  /**
+   * [iOS only] whether to allow duplicate peripheral during a scan
    */
   allowDuplicates?: boolean;
   /**
-   * This will only works if a ScanFilter is active. Otherwise, may not retrieve any result.
+   * [Android only] This will only work if a ScanFilter is active. Otherwise, may not retrieve any result.
    * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings#MATCH_NUM_FEW_ADVERTISEMENT.
    * */
   numberOfMatches?: BleScanMatchCount;
+  /**
+   * [Android only] Defaults to `aggressive`.
+   */
   matchMode?: BleScanMatchMode;
   /**
-   * This will only works if a ScanFilter is active. Otherwise, may not retrieve any result.
+   * [Android only] This will only work if a ScanFilter is active. Otherwise, may not retrieve any result.
    * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings#CALLBACK_TYPE_FIRST_MATCH.
    * Also read [this issue](https://github.com/dariuszseweryn/RxAndroidBle/issues/561#issuecomment-532295346) for a deeper understanding
-   * of the very brittle stability of ScanSettings on android.
+   * of the very brittle stability of ScanSettings on Android. Defaults to `allMatches`. 
    * */
   callbackType?: BleScanCallbackType;
+  /**
+   * [Android only] Defaults to `lowPower`.
+   */
   scanMode?: BleScanMode;
   /**
-   * This is supposed to push results after a certain delay.
+   * [Android only] This is supposed to push results after a certain delay.
    * In practice it is tricky, use with caution.
    * Do not set something below 5000ms as it will wait that long anyway before pushing the first results,
    * or on some phones it will ignore that setting and behave just like it was set to 0.
@@ -124,29 +147,20 @@ export interface ScanOptions {
    */
   reportDelay?: number;
   /**
-   * Does not work in conjunction with legacy scans. Setting an unsupported PHY will result in a failure to scan,
+   * [Android only] Does not work in conjunction with legacy scans. Setting an unsupported PHY will result in a failure to scan,
    * use with caution.
    * https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setPhy(int)
    */
   phy?: BleScanPhyMode;
   /**
-   * true by default for compatibility with older apps.
+   * [Android only] true by default for compatibility with older apps.
    * In that mode, scan will only retrieve advertisements data as specified by BLE 4.2 and below.
    * Change this if you want to benefit from the extended BLE 5 advertisement spec.
    * https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)
    */
   legacy?: boolean;
   /**
-   * an android ScanFilter, used if present to restrict scan results to devices with a specific advertising name.
-   * This is a whole word match, not a partial search.
-   * Use with caution, it's behavior is tricky and seems to be the following:
-   * if `callbackType` is set to `AllMatches`, only the completeLocalName will be used for filtering.
-   * if `callbackType` is set to `FirstMatch`, the shortenedLocalName will be used for filtering.
-   * https://developer.android.com/reference/android/bluetooth/le/ScanFilter.Builder#setDeviceName(java.lang.String)
-   */
-  exactAdvertisingName?: string | string[];
-  /**
-   * Android only. Filters scan results by manufacturer id and data.
+   * [Android only] Filters scan results by manufacturer id and data.
    * `manufacturerId` usually matches the company id, can be given as a hex, e.g. 0xe4f7.
    * `manufacturerData` and `manufacturerDataMask` must have the same length. For any bit in the mask, set it to 1 if
    * it needs to match the one in manufacturer data, otherwise set it to 0.
@@ -158,13 +172,6 @@ export interface ScanOptions {
     manufacturerDataMask?: number[];
   };
   /**
-   * When using compaion mode, only associate single peripheral.
-   *
-   * See: https://developer.android.com/reference/android/companion/AssociationRequest.Builder#setSingleDevice(boolean)
-   */
-  single?: boolean;
-  companion?: boolean;
-  /**
    * [Android O+] Deliver scan results using a PendingIntent instead of the default callback.
    */
   useScanIntent?: boolean;
@@ -172,13 +179,13 @@ export interface ScanOptions {
 
 export interface CompanionScanOptions {
   /**
-   * Scan only for a single peripheral.
+   * Scan only for a single peripheral. See Android's `AssociationRequest.Builder.setSingleDevice`.
    */
   single?: boolean;
 }
 
 /**
- * [android only]
+ * [Android only]
  */
 export enum BleScanMode {
   Opportunistic = -1,
@@ -188,7 +195,7 @@ export enum BleScanMode {
 }
 
 /**
- * [android only]
+ * [Android only]
  */
 export enum BleScanMatchMode {
   Aggressive = 1,
@@ -196,7 +203,7 @@ export enum BleScanMatchMode {
 }
 
 /**
- * [android only]
+ * [Android only]
  */
 export enum BleScanCallbackType {
   AllMatches = 1,
@@ -205,7 +212,7 @@ export enum BleScanCallbackType {
 }
 
 /**
- * [android only]
+ * [Android only]
  */
 export enum BleScanMatchCount {
   OneAdvertisement = 1,
@@ -214,7 +221,7 @@ export enum BleScanMatchCount {
 }
 
 /**
- * [android only]
+ * [Android only]
  */
 export enum BleScanPhyMode {
   LE_1M = 1,
@@ -224,7 +231,7 @@ export enum BleScanPhyMode {
 }
 
 /**
- * [android only API 21+]
+ * [Android only API 21+]
  */
 export enum ConnectionPriority {
   balanced = 0,
@@ -268,37 +275,20 @@ export interface PeripheralInfo extends Peripheral {
   services?: Service[];
 }
 
-export enum BleEventType {
-  BleManagerDidUpdateState = 'BleManagerDidUpdateState',
-  BleManagerStopScan = 'BleManagerStopScan',
-  BleManagerDiscoverPeripheral = 'BleManagerDiscoverPeripheral',
-  BleManagerDidUpdateValueForCharacteristic = 'BleManagerDidUpdateValueForCharacteristic',
-  BleManagerConnectPeripheral = 'BleManagerConnectPeripheral',
-  BleManagerDisconnectPeripheral = 'BleManagerDisconnectPeripheral',
-  /**
-   * [Android only]
-   */
-  BleManagerPeripheralDidBond = 'BleManagerPeripheralDidBond',
-  /**
-   * [iOS only]
-   */
-  BleManagerCentralManagerWillRestoreState = 'BleManagerCentralManagerWillRestoreState',
-  /**
-   * [iOS only]
-   */
-  BleManagerDidUpdateNotificationStateFor = 'BleManagerDidUpdateNotificationStateFor',
-}
-
 export type EventCallback<T> = (event: T) => void | Promise<void>;
 
 export interface BleStopScanEvent {
   /**
-   * [iOS only]
+   * [iOS] The reason for stopping the scan. Error code 10 is used for timeouts, 0 covers everything else.
+   * [Android] The reason for stopping the scan (<https://developer.android.com/reference/android/bluetooth/le/ScanCallback#constants_1>). Error code 10 is used for timeouts
    */
   status?: number;
 }
 
 export interface BleManagerDidUpdateStateEvent {
+  /**
+   * The new BLE state
+   */
   state: BleState;
 }
 
@@ -308,7 +298,9 @@ export interface BleConnectPeripheralEvent {
    */
   readonly peripheral: string;
   /**
-   * [android only]
+   * [Android only]
+   * 
+   * Connect reason.
    */
   readonly status?: number;
 }
@@ -326,7 +318,7 @@ export interface BleDisconnectPeripheralEvent {
    */
   readonly peripheral: string;
   /**
-   * [android only] disconnect reason.
+   * [Android only] disconnect reason.
    */
   readonly status?: number;
   /**


### PR DESCRIPTION
The existing JSDoc was already quite nice, but I still found myself frequently switching between the docs and my editor.
After also noticing that some small pieces of information existed in the inline JSDoc but not in the main documentation, this felt like a good opportunity to compare and align them.

About 90% of these changes are simple copy/paste moves between the docs and the JSDoc.

Some additional changes:
- Added references to relevant methods for `scan` and `startNotification`.
  This should make it slightly easier to understand where the results of these methods can be found.
    - For `scan`: `onDiscoverPeripheral` and `getDiscoveredPeripherals`
    - For `startNotification`: `onDidUpdateValueForCharacteristic`
- Moved `exactAdvertisingName` higher in the list of scan options, since it applies to both iOS and Android.
  The options are now ordered as common options first, followed by platform-specific ones.
- Removed the `single` and `companion` scan option types.
  These appear to have moved to the dedicated `companionScan` method and were already no longer documented.
- Removed `BleEventType` from `types.ts`.
  This no longer appears to be referenced and is likely a leftover from the `on('event', callback)` → `onEvent(callback)` changes?
- While making these changes, I also fixed some small inconsistencies I came across.
  Things like casing, section ordering, and adding an extra example here and there. Nothing major.

Happy to change anything, split up the PR if you don’t agree with a subset of any of these changes, or discuss further!