### PR TITLE
fix(ios): validate UUID format in getConnectedPeripherals to prevent crash

### DIFF
--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -696,6 +696,28 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
         var serviceUUIDs: [CBUUID] = []
 
         for uuidString in serviceUUIDStrings {
+            // Check for empty string
+            if uuidString.isEmpty {
+                let error = "Invalid UUID: empty string"
+                NSLog(error)
+                callback([error])
+                return
+            }
+            
+            // Validate BLE UUID format to prevent CBUUID(string:) crash
+            // BLE supports both 16-bit (4 hex chars) and 128-bit (standard UUID) formats
+            let hexCharacterSet = CharacterSet(charactersIn: "0123456789ABCDEFabcdef")
+            let isValid16Bit = uuidString.count == 4 && uuidString.rangeOfCharacter(from: hexCharacterSet.inverted) == nil
+            let isValid128Bit = UUID(uuidString: uuidString) != nil
+            
+            guard isValid16Bit || isValid128Bit else {
+                let error = "Invalid UUID format: \(uuidString)"
+                NSLog(error)
+                callback([error])
+                return
+            }
+            
+            // Create CBUUID only with validated UUID string (prevents crash)
             serviceUUIDs.append(CBUUID(string: uuidString))
         }
 


### PR DESCRIPTION
## Description

Fixes a crash in `getConnectedPeripherals` when invalid UUID strings are passed as service UUIDs. Previously, passing invalid UUID strings (e.g., "test") would cause the app to crash when `CBUUID(string:)` was called.

## Changes

- Added UUID format validation before creating `CBUUID` instances
- Validates both 16-bit (4 hex characters) and 128-bit (standard UUID format) BLE UUID formats
- Returns error callback instead of crashing when invalid UUID is detected
- Added empty string check

## Technical Details

The fix validates UUID strings in two ways:
1. **16-bit UUID**: Checks if string is exactly 4 hexadecimal characters (e.g., "180F")
2. **128-bit UUID**: Uses `UUID(uuidString:)` to validate standard UUID format

Invalid UUIDs now return an error callback: `["Invalid UUID format: <uuidString>"]` instead of causing a crash.

## Testing

- Valid 16-bit UUID: `"180F"` - works correctly
- Valid 128-bit UUID: `"0000180F-0000-1000-8000-00805F9B34FB"` - works correctly
- Invalid UUID: `"test"` - returns error instead of crashing
- Empty string: `""` - returns error instead of crashing