### PR TITLE
fix(ios): emit structured { code, domain, message } on callback errors

### DIFF
--- a/ios/SwiftBleManager.swift
+++ b/ios/SwiftBleManager.swift
@@ -32,6 +32,15 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
 
     private let serialQueue = DispatchQueue(label: "BleManager.serialQueue")
 
+    // Structured error payload so JS can detect specific failures by (domain, code).
+    private static func errorPayload(_ error: Error) -> [String: Any] {
+        return [
+            "code": error._code,
+            "domain": error._domain,
+            "message": error.localizedDescription,
+        ]
+    }
+
     private var exactAdvertisingName: [String]
 
     static var verboseLogging = false
@@ -1241,14 +1250,17 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
         didFailToConnect peripheral: CBPeripheral,
         error: Error?
     ) {
-        let errorStr =
+        NSLog(
             "Peripheral connection failure: \(peripheral.uuidAsString() ) (\(error?.localizedDescription ?? "")"
-        NSLog(errorStr)
+        )
 
+        let errorParam: Any =
+            error.map(SwiftBleManager.errorPayload)
+            ?? "Peripheral connection failure: \(peripheral.uuidAsString())"
         invokeAndClearDictionary(
             &connectCallbacks,
             withKey: peripheral.uuidAsString(),
-            usingParameters: [errorStr]
+            usingParameters: [errorParam]
         )
     }
 
@@ -1460,7 +1472,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
             invokeAndClearDictionary(
                 &retrieveServicesCallbacks,
                 withKey: peripheral.uuidAsString(),
-                usingParameters: [error.localizedDescription]
+                usingParameters: [SwiftBleManager.errorPayload(error)]
             )
             return
         }
@@ -1612,7 +1624,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
             invokeAndClearDictionary(
                 &readRSSICallbacks,
                 withKey: peripheral.uuidAsString(),
-                usingParameters: [error.localizedDescription, RSSI]
+                usingParameters: [SwiftBleManager.errorPayload(error), RSSI]
             )
         } else {
             invokeAndClearDictionary(
@@ -1641,7 +1653,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
             invokeAndClearDictionary(
                 &readDescriptorCallbacks,
                 withKey: key,
-                usingParameters: [error.localizedDescription, NSNull()]
+                usingParameters: [SwiftBleManager.errorPayload(error), NSNull()]
             )
             return
         }
@@ -1723,7 +1735,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
             invokeAndClearDictionary(
                 &readCallbacks,
                 withKey: key,
-                usingParameters: [error.localizedDescription, NSNull()]
+                usingParameters: [SwiftBleManager.errorPayload(error), NSNull()]
             )
             return
         }
@@ -1880,7 +1892,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
                 invokeAndClearDictionary(
                     &writeDescriptorCallbacks,
                     withKey: key,
-                    usingParameters: [error.localizedDescription]
+                    usingParameters: [SwiftBleManager.errorPayload(error)]
                 )
             } else {
                 invokeAndClearDictionary(
@@ -1911,7 +1923,7 @@ public class SwiftBleManager: NSObject, CBCentralManagerDelegate,
                 invokeAndClearDictionary(
                     &writeCallbacks,
                     withKey: key,
-                    usingParameters: [error.localizedDescription]
+                    usingParameters: [SwiftBleManager.errorPayload(error)]
                 )
                 serialQueue.sync {
                     writeQueues.removeValue(forKey: key)


### PR DESCRIPTION
## Motivation

When a CoreBluetooth operation fails, the iOS bridge currently passes `error.localizedDescription` to JS callbacks as the error parameter:

```swift
usingParameters: [error.localizedDescription, NSNull()]
```

`localizedDescription` is a system-generated, **locale-dependent** string that Apple does not contract to keep stable across iOS releases.
That makes it unreliable as a discriminator for specific failure modes — JS-side detection has to substring-match English text, which breaks on non-English devices and may break on future iOS versions.

The concrete case that prompted this PR: on iOS, when the user taps **Cancel** on the system pairing PIN dialog during a pairing-protected characteristic read, the failure surfaces as `CBATTErrorDomain` / code `15` (`CBATTErrorInsufficientEncryption`).
We want to detect this and skip our retry loop (retrying just re-prompts the user, which is poor UX), but the only signal currently reaching JS is the localized string `"Encryption is insufficient."` — undocumented, locale-fragile, and Apple provides no dedicated "user cancelled pairing" error to disambiguate.

The bridge already emits a structured `{domain, code, description}` payload for `didDisconnectPeripheral` and `didUpdateNotificationStateFor`.
This PR brings the rest of the error-emitting callbacks in line.

## What this PR does

Adds a small helper:

```swift
// Structured error payload so JS can detect specific failures by (domain, code).
private static func errorPayload(_ error: Error) -> [String: Any] {
    return [
        "code": error._code,
        "domain": error._domain,
        "message": error.localizedDescription,
    ]
}
```

…and switches the callback-emission sites in `SwiftBleManager.swift` to pass the dict in place of the bare `localizedDescription`:

- `didFailToConnect`
- `didDiscoverServices` (retrieveServices error path)
- `peripheral:didReadRSSI:`
- `didUpdateValueFor descriptor:` (readDescriptor)
- `didUpdateValueFor characteristic:` (read)
- `didWriteValueFor descriptor:`
- `didWriteValueFor characteristic:`

Untouched:

- `didDisconnectPeripheral` — already emits a structured event payload.
- `didUpdateNotificationStateFor` — already emits structured `domain`/`code` via `emitOnDidUpdateNotificationState`; the callback path forwards the raw `NSError`.

## Breaking change

The error parameter delivered to JS for `read`, `write`, `connect`, `retrieveServices`, `readRSSI`, `readDescriptor`, and `writeDescriptor` is now an object on iOS rather than a string.
Android is unaffected.

Before:

```ts
BleManager.read(...).catch((err) => {
  // err === "Encryption is insufficient."
})
```

After:

```ts
BleManager.read(...).catch((err) => {
  // err === { code: 15, domain: "CBATTErrorDomain", message: "Encryption is insufficient." }
  if (err?.domain === "CBATTErrorDomain" && err?.code === 15) {
    // user cancelled iOS pairing prompt (or peripheral lacks encryption keys)
  }
})
```

Callers that only logged the error (`console.error(err)`) continue to work — both strings and dicts serialize sensibly.
Callers that substring-matched on the localized text need to switch to `err.message`, or better, to `(err.domain, err.code)`.
The TS types in `src/index.ts` should probably be updated in a follow-up to reflect `BleError = { code: number; domain: string; message: string } | null` for the iOS path.

## Alternatives considered

1. **Backward-compatible string prefix** — emit `"[CBATTErrorDomain 15] Encryption is insufficient."` instead of a dict.
   Rejected: callers that currently display `localizedDescription` directly to the user would now show the bracketed prefix in the UI.
2. **Leave the API and document the magic strings.**
   Rejected: Apple does not document them and they vary by locale.

## Testing

Verified locally via `yarn patch` against an iOS 26.1 device with a pairing-protected peripheral: the JS-side `err` is now `{ code: 15, domain: "CBATTErrorDomain", message: "Encryption is insufficient." }` on user-cancel, and the retry-skip logic in our app fires as expected.
No change on the success path.
