### PR TITLE
fix: can't disconnect ble on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,8 @@ buildscript {
         }
 
         dependencies {
-            classpath "com.android.tools.build:gradle:7.2.1"
+            classpath "com.android.tools.build:gradle:8.6.1"
+            classpath "com.facebook.react:react-native-gradle-plugin"
             // noinspection DifferentKotlinGradleVersion
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         }
@@ -28,10 +29,7 @@ def isNewArchitectureEnabled() {
 
 apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: 'com.facebook.react'
-}
+apply plugin: 'com.facebook.react'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -116,17 +114,12 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-    // For < 0.71, this will be from the local maven repo
-    // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-    //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-android:0.81.5"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
-if (isNewArchitectureEnabled()) {
-    react {
-        jsRootDir = file("../src/")
-        libraryName = "BleManager"
-        codegenJavaPackageName = "it.innove"
-    }
+react {
+    jsRootDir = file("../src/")
+    libraryName = "BleManager"
+    codegenJavaPackageName = "it.innove"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.7.0
+kotlinVersion=1.9.24
 android.useAndroidX=true
 android.enableJetifier=true
 # https://github.com/facebook/react-native/issues/35168

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'react-native-ble-manager'
 
+includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -118,69 +118,69 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void connect(final Callback callback, Activity activity, ReadableMap options) {
-    mainHandler.post(() -> {
-        if (connected) {
-            if (gatt != null) {
-                callback.invoke();
-            } else {
-                callback.invoke("BluetoothGatt is null");
-            }
-            return;
-        }
-
-        this.connectCallbacks.addLast(callback);
-
-        if (connecting) {
-            return;
-        }
-
-        BluetoothDevice device = getDevice();
-        this.connecting = true;
-
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
-                boolean autoconnect = false;
-                if (options.hasKey("autoconnect")) {
-                    autoconnect = options.getBoolean("autoconnect");
-                }
-                if (!autoconnect && options.hasKey("phy") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    int phy = options.getInt("phy");
-                    gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE, phy);
+        mainHandler.post(() -> {
+            if (connected) {
+                if (gatt != null) {
+                    callback.invoke();
                 } else {
-                    gatt = device.connectGatt(activity, autoconnect, this, BluetoothDevice.TRANSPORT_LE);
+                    callback.invoke("BluetoothGatt is null");
                 }
-            } else {
-                Log.d(BleManager.LOG_TAG, " Less than M");
-                try {
-                    Log.d(BleManager.LOG_TAG, " Trying TRANPORT LE with reflection");
-                    Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class,
-                            BluetoothGattCallback.class, Integer.class);
-                    m.setAccessible(true);
-                    Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
-                    gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    Log.d(TAG, " Catch to call normal connection");
-                    gatt = device.connectGatt(activity, false, this);
-                }
+                return;
             }
 
-            // connectGatt() may return null if the adapter is not ready
-            if (gatt == null) {
-                throw new Exception("connectGatt returned null");
+            this.connectCallbacks.addLast(callback);
+
+            if (connecting) {
+                return;
             }
-        } catch (Exception e) {
-            Log.e(BleManager.LOG_TAG, "[ON CONNECT][NATIVE] connectGatt failed for " + device.getAddress(), e);
-            this.connecting = false;
-            this.gatt = null;
-            for (Callback connectCallback : connectCallbacks) {
-                connectCallback.invoke("Connection failed to start: " + e.getMessage());
+
+            BluetoothDevice device = getDevice();
+            this.connecting = true;
+
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
+                    boolean autoconnect = false;
+                    if (options.hasKey("autoconnect")) {
+                        autoconnect = options.getBoolean("autoconnect");
+                    }
+                    if (!autoconnect && options.hasKey("phy") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        int phy = options.getInt("phy");
+                        gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE, phy);
+                    } else {
+                        gatt = device.connectGatt(activity, autoconnect, this, BluetoothDevice.TRANSPORT_LE);
+                    }
+                } else {
+                    Log.d(BleManager.LOG_TAG, " Less than M");
+                    try {
+                        Log.d(BleManager.LOG_TAG, " Trying TRANPORT LE with reflection");
+                        Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class,
+                                BluetoothGattCallback.class, Integer.class);
+                        m.setAccessible(true);
+                        Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
+                        gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        Log.d(TAG, " Catch to call normal connection");
+                        gatt = device.connectGatt(activity, false, this);
+                    }
+                }
+
+                // connectGatt() may return null if the adapter is not ready
+                if (gatt == null) {
+                    throw new IllegalStateException("connectGatt returned null");
+                }
+            } catch (Exception e) {
+                Log.e(BleManager.LOG_TAG, "[ON CONNECT][NATIVE] connectGatt failed for " + device.getAddress(), e);
+                this.connecting = false;
+                this.gatt = null;
+                for (Callback connectCallback : connectCallbacks) {
+                    connectCallback.invoke("Connection failed to start: " + e.getMessage());
+                }
+                connectCallbacks.clear();
             }
-            connectCallbacks.clear();
-        }
-    });
-}
+        });
+    }
     // bt_btif : Register with GATT stack failed.
 
     public void disconnect(final Callback callback, final boolean force) {
@@ -1124,33 +1124,33 @@ public class Peripheral extends BluetoothGattCallback {
         }
         return enqueue(() -> {
             try {
-                 if (!isConnected() || gatt == null) {
-                     if (withResponse && callback != null) {
-                         if (writeCallbacks.removeLastOccurrence(callback)) {
-                             try {
-                                 callback.invoke("Device is not connected", null);
-                             } catch (Exception callbackException) {
-                                 Log.e(BleManager.LOG_TAG, "Error invoking write callback for disconnected device", callbackException);
-                             }
-                         }
-                     }
-                     completedCommand();
-                     return;
-                 }
-                 doWrite(characteristic, copyOfData);
-             } catch (Exception e) {
-                 Log.e(BleManager.LOG_TAG, "Error in enqueueWrite lambda", e);
-                 if (withResponse && callback != null) {
-                     if (writeCallbacks.removeLastOccurrence(callback)) {
-                         try {
-                             callback.invoke("Write failed: " + e.getMessage(), null);
-                         } catch (Exception callbackException) {
-                             Log.e(BleManager.LOG_TAG, "Error invoking write callback", callbackException);
-                         }
-                     }
-                 }
-                 completedCommand();
-             }
+                if (!isConnected() || gatt == null) {
+                    if (withResponse && callback != null) {
+                        if (writeCallbacks.removeLastOccurrence(callback)) {
+                            try {
+                                callback.invoke("Device is not connected", null);
+                            } catch (Exception callbackException) {
+                                Log.e(BleManager.LOG_TAG, "Error invoking write callback for disconnected device", callbackException);
+                            }
+                        }
+                    }
+                    completedCommand();
+                    return;
+                }
+                doWrite(characteristic, copyOfData);
+            } catch (Exception e) {
+                Log.e(BleManager.LOG_TAG, "Error in enqueueWrite lambda", e);
+                if (withResponse && callback != null) {
+                    if (writeCallbacks.removeLastOccurrence(callback)) {
+                        try {
+                            callback.invoke("Write failed: " + e.getMessage(), null);
+                        } catch (Exception callbackException) {
+                            Log.e(BleManager.LOG_TAG, "Error invoking write callback", callbackException);
+                        }
+                    }
+                }
+                completedCommand();
+            }
         });
     }
 

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -118,51 +118,74 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void connect(final Callback callback, Activity activity, ReadableMap options) {
-        mainHandler.post(() -> {
-            if (!connected) {
-                BluetoothDevice device = getDevice();
-                this.connectCallbacks.addLast(callback);
-                this.connecting = true;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
-                    boolean autoconnect = false;
-                    if (options.hasKey("autoconnect")) {
-                        autoconnect = options.getBoolean("autoconnect");
-                    }
-                    if (!autoconnect && options.hasKey("phy") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        int phy = options.getInt("phy");
-                        gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE, phy);
-                    } else {
-                        gatt = device.connectGatt(activity, autoconnect, this, BluetoothDevice.TRANSPORT_LE);
-                    }
+    mainHandler.post(() -> {
+        if (connected) {
+            if (gatt != null) {
+                callback.invoke();
+            } else {
+                callback.invoke("BluetoothGatt is null");
+            }
+            return;
+        }
+
+        this.connectCallbacks.addLast(callback);
+
+        if (connecting) {
+            return;
+        }
+
+        BluetoothDevice device = getDevice();
+        this.connecting = true;
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
+                boolean autoconnect = false;
+                if (options.hasKey("autoconnect")) {
+                    autoconnect = options.getBoolean("autoconnect");
+                }
+                if (!autoconnect && options.hasKey("phy") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    int phy = options.getInt("phy");
+                    gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE, phy);
                 } else {
-                    Log.d(BleManager.LOG_TAG, " Less than M");
-                    try {
-                        Log.d(BleManager.LOG_TAG, " Trying TRANPORT LE with reflection");
-                        Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class,
-                                BluetoothGattCallback.class, Integer.class);
-                        m.setAccessible(true);
-                        Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
-                        gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        Log.d(TAG, " Catch to call normal connection");
-                        gatt = device.connectGatt(activity, false, this);
-                    }
+                    gatt = device.connectGatt(activity, autoconnect, this, BluetoothDevice.TRANSPORT_LE);
                 }
             } else {
-                if (gatt != null) {
-                    callback.invoke();
-                } else {
-                    callback.invoke("BluetoothGatt is null");
+                Log.d(BleManager.LOG_TAG, " Less than M");
+                try {
+                    Log.d(BleManager.LOG_TAG, " Trying TRANPORT LE with reflection");
+                    Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class,
+                            BluetoothGattCallback.class, Integer.class);
+                    m.setAccessible(true);
+                    Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
+                    gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    Log.d(TAG, " Catch to call normal connection");
+                    gatt = device.connectGatt(activity, false, this);
                 }
             }
-        });
-    }
+
+            // connectGatt() may return null if the adapter is not ready
+            if (gatt == null) {
+                throw new Exception("connectGatt returned null");
+            }
+        } catch (Exception e) {
+            Log.e(BleManager.LOG_TAG, "[ON CONNECT][NATIVE] connectGatt failed for " + device.getAddress(), e);
+            this.connecting = false;
+            this.gatt = null;
+            for (Callback connectCallback : connectCallbacks) {
+                connectCallback.invoke("Connection failed to start: " + e.getMessage());
+            }
+            connectCallbacks.clear();
+        }
+    });
+}
     // bt_btif : Register with GATT stack failed.
 
     public void disconnect(final Callback callback, final boolean force) {
         connected = false;
+        connecting = false;
         mainHandler.post(() -> {
             errorAndClearAllCallbacks("Disconnect called before the command completed");
             resetQueuesAndBuffers();
@@ -384,6 +407,7 @@ public class Peripheral extends BluetoothGattCallback {
         commandQueue.clear();
         commandQueueBusy = false;
         connected = false;
+        connecting = false;
         clearBuffers();
     }
 


### PR DESCRIPTION
Fix Android BLE reconnect issues caused by stale BluetoothGatt / connection state after disconnects.
This patches react-native-ble-manager to avoid duplicate native connect attempts.

The root cause:
The user calls connect multiple times simultaneously, so although disconnect returns success, the app does not actually disconnect.

References:

https://stackoverflow.com/questions/35986549/totally-disconnect-a-bluetooth-low-energy-device/36005877#36005877 

https://github.com/innoveit/react-native-ble-manager/issues/795 